### PR TITLE
Support for Java's "for each" with Iterable interface

### DIFF
--- a/generator/src/main/java/org/stjs/generator/GeneratorConfigurationBuilder.java
+++ b/generator/src/main/java/org/stjs/generator/GeneratorConfigurationBuilder.java
@@ -142,6 +142,9 @@ public class GeneratorConfigurationBuilder {
 		allowedJavaLangClasses.add("Exception");
 		allowedJavaLangClasses.add("RuntimeException");
 
+		// java.lang's Interfaces
+		allowedJavaLangClasses.add(Iterable.class.getSimpleName());
+
 		allowedPackages.add("java.lang");
 
 		return new GeneratorConfiguration(//

--- a/generator/src/main/java/org/stjs/generator/writer/statement/EnhancedForLoopWriter.java
+++ b/generator/src/main/java/org/stjs/generator/writer/statement/EnhancedForLoopWriter.java
@@ -1,6 +1,6 @@
 package org.stjs.generator.writer.statement;
 
-import java.util.Collections;
+import java.util.*;
 
 import javax.lang.model.type.TypeMirror;
 
@@ -48,7 +48,8 @@ public class EnhancedForLoopWriter<JS> implements WriterContributor<EnhancedForL
 		JS not =
 				js.unary(
 						UnaryOperator.LOGICAL_COMPLEMENT,
-						js.functionCall(js.property(js.paren(iterated), "hasOwnProperty"),
+						js.functionCall(
+								js.property(js.paren(iterated), "hasOwnProperty"),
 								Collections.singleton(js.name(tree.getVariable().getName()))));
 
 		JS ifs = js.ifStatement(not, js.continueStatement(null), null);
@@ -57,11 +58,74 @@ public class EnhancedForLoopWriter<JS> implements WriterContributor<EnhancedForL
 
 	@Override
 	public JS visit(WriterVisitor<JS> visitor, EnhancedForLoopTree tree, GenerationContext<JS> context) {
+		// Java Statement
+		//     for (String s : myCollection)
+		// Scanned values
+		//     iterator = (VariableDeclaration) --> "String s"
+		//     iterated = (Name) --> "myCollection"
 		JS iterator = visitor.scan(tree.getVariable(), context);
 		JS iterated = visitor.scan(tree.getExpression(), context);
 		JS body = visitor.scan(tree.getStatement(), context);
 
+		TypeMirror iteratedType = InternalUtils.typeOf(tree.getExpression());
+
+		if (TypesUtils.isDeclaredOfName(iteratedType, Array.class.getName())) {
+			return generateForEachInArray(tree, context, iterator, iterated, body);
+		} else if (isErasuredClassAssignableFromType(Iterable.class, iteratedType, context)){
+			return generateForEachWithIterable(tree, context, iterated, body);
+		} else {
+			return context.withPosition(tree, context.js().forInLoop(iterator, iterated, body));
+		}
+	}
+
+	private boolean isErasuredClassAssignableFromType(Class clazz, TypeMirror iteratedType, GenerationContext<JS> context) {
+		TypeMirror erasedClassToCheck = context.getTypes().erasure(TypesUtils.typeFromClass(context.getTypes(), context.getElements(), clazz));
+		TypeMirror erasedIteratedType = context.getTypes().erasure(iteratedType);
+
+		return context.getTypes().isAssignable(erasedIteratedType, erasedClassToCheck);
+	}
+
+	private boolean isJavaArray(TypeMirror iteratedType, GenerationContext<JS> context) {
+
+		TypeMirror erasedType = context.getTypes().erasure(iteratedType);
+		return erasedType != null;
+	}
+
+	private JS generateForEachInArray(EnhancedForLoopTree tree, GenerationContext<JS> context, JS iterator, JS iterated, JS body) {
 		body = generateArrayHasOwnProperty(tree, context, iterated, body);
 		return context.withPosition(tree, context.js().forInLoop(iterator, iterated, body));
 	}
+
+	private JS generateForEachWithIterable(EnhancedForLoopTree tree, GenerationContext<JS> context, JS iterated, JS body) {
+		JavaScriptBuilder<JS> js = context.js();
+
+		// Java source code:
+		// ---------------------------------------------
+		//	 for (String oneOfTheString : myStringList) {
+		//	   // do whatever you want with 'oneOfTheString'
+		//	 }
+		//
+		// Translated Javascript:
+		// ---------------------------------------------
+		//   for (var iterator$oneOfTheString = myStringList.iterator(); iterator$oneOfTheString.hasNext(); ) {
+		//     var oneOfTheString = iterator$oneOfTheString.next();
+		//   }
+		String initialForLoopVariableName = tree.getVariable().getName().toString();
+
+		JS iteratorMethodCall = js.functionCall(
+				js.property(iterated, "iterator"),
+				Collections.<JS>emptyList());
+
+		String newIteratorName = "iterator$" + initialForLoopVariableName;
+		JS forLoopIterator = js.name(newIteratorName);
+		JS init = js.variableDeclaration(false, newIteratorName, iteratorMethodCall);
+		JS condition = js.functionCall(js.property(forLoopIterator, "hasNext"), Collections.<JS>emptyList());
+		JS update = js.emptyExpression();
+
+		JS iteratorNextStatement = js.variableDeclaration(true, initialForLoopVariableName, js.functionCall(js.property(forLoopIterator, "next"), Collections.<JS>emptyList()));
+		body = js.addStatementBeginning(body, iteratorNextStatement);
+
+		return context.withPosition(tree, context.js().forLoop(init, condition, update, body));
+	}
+
 }

--- a/generator/src/test/java/org/stjs/generator/writer/statements/Statements22_ForEachIterable.java
+++ b/generator/src/test/java/org/stjs/generator/writer/statements/Statements22_ForEachIterable.java
@@ -1,0 +1,8 @@
+package org.stjs.generator.writer.statements;
+
+public class Statements22_ForEachIterable {
+    public static void main(Iterable<String> myStringList) {
+        for (String oneOfTheString : myStringList) {
+        }
+    }
+}

--- a/generator/src/test/java/org/stjs/generator/writer/statements/StatementsGeneratorTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/statements/StatementsGeneratorTest.java
@@ -86,6 +86,11 @@ public class StatementsGeneratorTest extends AbstractStjsTest {
 	}
 
 	@Test
+	public void testForEachInWithIterable() {
+		assertCodeContains(Statements22_ForEachIterable.class, "for (var iterator$oneOfTheString = myStringList.iterator(); iterator$oneOfTheString.hasNext(); ) { var oneOfTheString = iterator$oneOfTheString.next(); }");
+	}
+
+	@Test
 	public void testForEachArrayBlock() {
 		assertCodeContains(Statements12.class, "if (!(a).hasOwnProperty(i)) continue;var x");
 	}


### PR DESCRIPTION
Support of Java's "for each" with Iterable.

The following Java code:

``` java
void anyFunc(List<String> myStringList) {    
    for (String oneOfTheString : myStringList) {
        // do whatever you want with 'oneOfTheString'
    }
}
```

Will be converted in Javascript to:

``` javascript
var myStringList = null;
for (var iterator$oneOfTheString = myStringList.iterator(); iterator$oneOfTheString.hasNext(); ) {
    var oneOfTheString = iterator$oneOfTheString.next()
    // do whatever you want with 'oneOfTheString'
}
```
