### PR TITLE
Decorate transpiled methods not public

### DIFF
--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -36,7 +36,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-            <version>17.0</version>
+            <version>18.0</version>
 		</dependency>
 
 		<dependency>

--- a/generator/src/main/java/org/stjs/generator/utils/JavaNodes.java
+++ b/generator/src/main/java/org/stjs/generator/utils/JavaNodes.java
@@ -49,6 +49,11 @@ public final class JavaNodes {
 		return modifiers.contains(Modifier.STATIC);
 	}
 
+	public static boolean isPublic(MethodTree method) {
+		Set<Modifier> modifiers = method.getModifiers().getFlags();
+		return modifiers.contains(Modifier.PUBLIC);
+	}
+
 	public static boolean isFinal(VariableTree tree) {
 		return tree.getModifiers().getFlags().contains(Modifier.FINAL);
 	}

--- a/generator/src/main/java/org/stjs/generator/writer/declaration/MethodWriter.java
+++ b/generator/src/main/java/org/stjs/generator/writer/declaration/MethodWriter.java
@@ -55,6 +55,14 @@ public class MethodWriter<JS> extends AbstractMemberWriter<JS> implements Writer
 		return null;
 	}
 
+	private String decorateMethodName(MethodTree tree, String methodName) {
+		if (!JavaNodes.isPublic(tree)) {
+			return "_" + methodName;
+		}
+
+		return methodName;
+	}
+
 	public static <JS> List<JS> getParams(List<? extends VariableTree> treeParams, GenerationContext<JS> context) {
 		List<JS> params = new ArrayList<JS>();
 		for (VariableTree param : treeParams) {
@@ -104,7 +112,7 @@ public class MethodWriter<JS> extends AbstractMemberWriter<JS> implements Writer
 
 		// add the constructor.<name> or prototype.<name> if needed
 		if (!JavaNodes.isConstructor(tree) && !isMethodOfJavascriptFunction(context.getCurrentWrapper())) {
-			String methodName = context.getNames().getMethodName(context, tree, context.getCurrentPath());
+			String methodName = decorateMethodName(tree, context.getNames().getMethodName(context, tree, context.getCurrentPath()));
 			if (tw.getEnclosingType().isGlobal()) {
 				// var method=function() ...; //for global types
 				return context.js().variableDeclaration(true, methodName, decl);
@@ -115,5 +123,4 @@ public class MethodWriter<JS> extends AbstractMemberWriter<JS> implements Writer
 
 		return decl;
 	}
-
 }

--- a/generator/src/main/java/org/stjs/generator/writer/expression/MethodInvocationWriter.java
+++ b/generator/src/main/java/org/stjs/generator/writer/expression/MethodInvocationWriter.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.stjs.generator.GenerationContext;
 import org.stjs.generator.javac.ElementUtils;
+import org.stjs.generator.javac.InternalUtils;
 import org.stjs.generator.javac.TreeUtils;
 import org.stjs.generator.javac.TreeWrapper;
 import org.stjs.generator.visitor.DiscriminatorKey;
@@ -18,6 +19,9 @@ import com.sun.source.tree.IdentifierTree;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.Tree;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.Modifier;
 
 public class MethodInvocationWriter<JS> implements WriterContributor<MethodInvocationTree, JS> {
 
@@ -44,11 +48,15 @@ public class MethodInvocationWriter<JS> implements WriterContributor<MethodInvoc
 		return targetJS;
 	}
 
-	public static String buildMethodName(MethodInvocationTree tree) {
+	public static <JS> String buildMethodName(MethodInvocationTree tree) {
 		ExpressionTree select = tree.getMethodSelect();
 		if (select instanceof IdentifierTree) {
 			// simple call: method(args)
-			return ((IdentifierTree) select).getName().toString();
+			String methodName = ((IdentifierTree) select).getName().toString();
+			Element element = InternalUtils.symbol(tree);
+			if (element != null) {
+				return !element.getModifiers().contains(Modifier.PUBLIC) ? "_" + methodName : methodName;
+			}
 		}
 		// calls with target: target.method(args)
 		MemberSelectTree memberSelect = (MemberSelectTree) select;

--- a/generator/src/test/java/org/stjs/generator/writer/methods/Methods2.java
+++ b/generator/src/test/java/org/stjs/generator/writer/methods/Methods2.java
@@ -2,7 +2,11 @@ package org.stjs.generator.writer.methods;
 
 public class Methods2 {
 	@SuppressWarnings("unused")
-	private int method(String arg1, String arg2) {
+	private int privateMethod(String arg1, String arg2) {
 		return 0;
+	}
+
+	public int method() {
+		return privateMethod("", "");
 	}
 }

--- a/generator/src/test/java/org/stjs/generator/writer/methods/MethodsGeneratorTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/methods/MethodsGeneratorTest.java
@@ -15,9 +15,13 @@ public class MethodsGeneratorTest extends AbstractStjsTest {
 	@Test
 	public void testPrivateInstanceMethod() {
 		// same as public
-		assertCodeContains(Methods2.class, //
-				"stjs.extend(Methods2, null, [], function(constructor, prototype){" + //
-						"prototype.method = function(arg1,arg2){");
+		assertCodeContains(Methods2.class, "" +
+				"prototype._privateMethod = function(arg1, arg2) {\n" +
+				"        return 0;\n" +
+				"    };\n" +
+				"    prototype.method = function() {\n" +
+				"        return this._privateMethod(\"\", \"\");\n" +
+				"    };");
 	}
 
 	@Test
@@ -31,7 +35,7 @@ public class MethodsGeneratorTest extends AbstractStjsTest {
 	public void testPrivateStaticMethod() {
 		assertCodeContains(Methods4.class, //
 				"stjs.extend(Methods4, null, [], function(constructor, prototype){" + //
-						"constructor.method = function(arg1,arg2){");
+						"constructor._method = function(arg1,arg2){");
 	}
 
 	@Test


### PR DESCRIPTION
To follow the javascript convention, let's prefix methods that aren't public with `_`.

Sorry for the upgrade to guava lost in this PR, we are getting structured and it slept trough ;)
