### PR TITLE
Prefix non-public fields

### DIFF
--- a/generator/src/main/java/org/stjs/generator/GeneratorConstants.java
+++ b/generator/src/main/java/org/stjs/generator/GeneratorConstants.java
@@ -49,6 +49,8 @@ public final class GeneratorConstants {
 	 */
 	public static final String STJS_TEST_TEMP_FOLDER = "stjs-test";
 
+	public static final String NON_PUBLIC_METHODS_AND_FIELDS_PREFIX = "_";
+
 	private GeneratorConstants() {
 		//
 	}

--- a/generator/src/main/java/org/stjs/generator/writer/declaration/FieldWriter.java
+++ b/generator/src/main/java/org/stjs/generator/writer/declaration/FieldWriter.java
@@ -4,9 +4,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.lang.model.element.Element;
+import javax.lang.model.element.Modifier;
 import javax.lang.model.type.TypeMirror;
 
 import org.stjs.generator.GenerationContext;
+import org.stjs.generator.GeneratorConstants;
 import org.stjs.generator.STJSRuntimeException;
 import org.stjs.generator.javac.TreeWrapper;
 import org.stjs.generator.javascript.AssignOperator;
@@ -77,6 +79,9 @@ public class FieldWriter<JS> extends AbstractMemberWriter<JS> implements WriterC
 		}
 
 		String fieldName = tree.getName().toString();
+		if (!tree.getModifiers().getFlags().contains(Modifier.PUBLIC)) {
+			fieldName = GeneratorConstants.NON_PUBLIC_METHODS_AND_FIELDS_PREFIX + fieldName;
+		}
 		if (tw.getEnclosingType().isGlobal()) {
 			// var field = init; //for global types
 			return context.js().variableDeclaration(true, fieldName, initializer);

--- a/generator/src/main/java/org/stjs/generator/writer/declaration/MethodWriter.java
+++ b/generator/src/main/java/org/stjs/generator/writer/declaration/MethodWriter.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
 
 import org.stjs.generator.GenerationContext;
 import org.stjs.generator.GeneratorConstants;
@@ -55,9 +56,12 @@ public class MethodWriter<JS> extends AbstractMemberWriter<JS> implements Writer
 		return null;
 	}
 
-	private String decorateMethodName(MethodTree tree, String methodName) {
-		if (!JavaNodes.isPublic(tree)) {
-			return "_" + methodName;
+	private String decorateMethodName(MethodTree tree, GenerationContext<JS> context) {
+		String methodName = context.getNames().getMethodName(context, tree, context.getCurrentPath());
+		boolean isFromInterface = context.getCurrentWrapper().getEnclosingType().getElement().getKind().equals(ElementKind.INTERFACE);
+
+		if (!JavaNodes.isPublic(tree) && !isFromInterface) {
+			return GeneratorConstants.NON_PUBLIC_METHODS_AND_FIELDS_PREFIX + methodName;
 		}
 
 		return methodName;
@@ -112,7 +116,7 @@ public class MethodWriter<JS> extends AbstractMemberWriter<JS> implements Writer
 
 		// add the constructor.<name> or prototype.<name> if needed
 		if (!JavaNodes.isConstructor(tree) && !isMethodOfJavascriptFunction(context.getCurrentWrapper())) {
-			String methodName = decorateMethodName(tree, context.getNames().getMethodName(context, tree, context.getCurrentPath()));
+			String methodName = decorateMethodName(tree, context);
 			if (tw.getEnclosingType().isGlobal()) {
 				// var method=function() ...; //for global types
 				return context.js().variableDeclaration(true, methodName, decl);

--- a/generator/src/main/java/org/stjs/generator/writer/expression/MethodInvocationWriter.java
+++ b/generator/src/main/java/org/stjs/generator/writer/expression/MethodInvocationWriter.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.stjs.generator.GenerationContext;
+import org.stjs.generator.GeneratorConstants;
 import org.stjs.generator.javac.ElementUtils;
 import org.stjs.generator.javac.InternalUtils;
 import org.stjs.generator.javac.TreeUtils;
@@ -55,7 +56,7 @@ public class MethodInvocationWriter<JS> implements WriterContributor<MethodInvoc
 			String methodName = ((IdentifierTree) select).getName().toString();
 			Element element = InternalUtils.symbol(tree);
 			if (element != null) {
-				return !element.getModifiers().contains(Modifier.PUBLIC) ? "_" + methodName : methodName;
+				return element.getModifiers().contains(Modifier.PUBLIC) ? methodName : GeneratorConstants.NON_PUBLIC_METHODS_AND_FIELDS_PREFIX + methodName;
 			}
 		}
 		// calls with target: target.method(args)

--- a/generator/src/main/java/org/stjs/generator/writer/templates/fields/DefaultIdentifierTemplate.java
+++ b/generator/src/main/java/org/stjs/generator/writer/templates/fields/DefaultIdentifierTemplate.java
@@ -2,10 +2,12 @@ package org.stjs.generator.writer.templates.fields;
 
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.Modifier;
 
 import org.stjs.generator.GenerationContext;
 import org.stjs.generator.GeneratorConstants;
 import org.stjs.generator.javac.ElementUtils;
+import org.stjs.generator.javac.InternalUtils;
 import org.stjs.generator.javac.TreeWrapper;
 import org.stjs.generator.javascript.Keyword;
 import org.stjs.generator.name.DependencyType;
@@ -23,7 +25,12 @@ import com.sun.source.tree.IdentifierTree;
 public class DefaultIdentifierTemplate<JS> implements WriterContributor<IdentifierTree, JS> {
 
 	private JS visitField(IdentifierTree tree, GenerationContext<JS> context) {
-		return context.js().property(MemberWriters.buildTarget(context.getCurrentWrapper()), tree.getName());
+		String fieldName = tree.getName().toString();
+		Element element = InternalUtils.symbol(tree);
+		if (element != null && !element.getModifiers().contains(Modifier.PUBLIC)) {
+			fieldName = GeneratorConstants.NON_PUBLIC_METHODS_AND_FIELDS_PREFIX + fieldName;
+		}
+		return context.js().property(MemberWriters.buildTarget(context.getCurrentWrapper()), fieldName);
 	}
 
 	private JS visitEnumConstant(Element def, IdentifierTree tree, GenerationContext<JS> context) {

--- a/generator/src/main/java/org/stjs/generator/writer/templates/fields/DefaultMemberSelectTemplate.java
+++ b/generator/src/main/java/org/stjs/generator/writer/templates/fields/DefaultMemberSelectTemplate.java
@@ -2,6 +2,7 @@ package org.stjs.generator.writer.templates.fields;
 
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.Modifier;
 
 import org.stjs.generator.GenerationContext;
 import org.stjs.generator.GeneratorConstants;
@@ -68,6 +69,17 @@ public class DefaultMemberSelectTemplate<JS> implements WriterContributor<Member
 			// When ClassName.class -> ClassName
 			return target;
 		}
-		return context.js().property(target, tree.getIdentifier().toString());
+
+		String fieldName = decorateMember(tree, element);
+
+		return context.js().property(target, fieldName);
+	}
+
+	private String decorateMember(MemberSelectTree tree, Element element) {
+		String fieldName = tree.getIdentifier().toString();
+		if (!element.getModifiers().contains(Modifier.PUBLIC)) {
+			fieldName = GeneratorConstants.NON_PUBLIC_METHODS_AND_FIELDS_PREFIX + fieldName;
+		}
+		return fieldName;
 	}
 }

--- a/generator/src/test/java/org/stjs/generator/writer/fields/Fields25_non_public_prefix.java
+++ b/generator/src/test/java/org/stjs/generator/writer/fields/Fields25_non_public_prefix.java
@@ -1,0 +1,72 @@
+package org.stjs.generator.writer.fields;
+
+public class Fields25_non_public_prefix {
+    String packageField;
+    private String privateField;
+    public String publicField;
+
+    public String getThisPackageField() {
+        Fields25_non_public_prefix myFields25nonpublicprefix = new Fields25_non_public_prefix();
+        myFields25nonpublicprefix.packageField = "test";
+
+        return this.packageField;
+    }
+
+    public String getThisPrivateField() {
+        return this.privateField;
+    }
+
+    public String getThisPublicField() {
+        return this.publicField;
+    }
+
+    public String getPackageField() {
+        return packageField;
+    }
+
+    public String getPrivateField() {
+        return privateField;
+    }
+
+    public String getPublicField() {
+        return publicField;
+    }
+
+    private static class InnerClass {
+        String innerPackageField;
+        private String innerPrivateField;
+        public String innerPublicField;
+        private Fields25_non_public_prefix parent;
+
+        public InnerClass(Fields25_non_public_prefix parent) {
+            this.parent = parent;
+        }
+
+        public String getThisPackageField() {
+            Fields25_non_public_prefix myFields25nonpublicprefix = new Fields25_non_public_prefix();
+            myFields25nonpublicprefix.packageField = "test";
+
+            return this.innerPackageField;
+        }
+
+        public String getThisPrivateField() {
+            return this.innerPrivateField;
+        }
+
+        public String getThisPublicField() {
+            return this.innerPublicField;
+        }
+
+        public String getPackageField() {
+            return parent.packageField;
+        }
+
+        public String getPrivateField() {
+            return parent.privateField;
+        }
+
+        public String getPublicField() {
+            return parent.publicField;
+        }
+    }
+}

--- a/generator/src/test/java/org/stjs/generator/writer/fields/FieldsGeneratorTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/fields/FieldsGeneratorTest.java
@@ -80,7 +80,63 @@ public class FieldsGeneratorTest extends AbstractStjsTest {
 
 	@Test
 	public void testPrivateFinalBooleanBug() {
-		assertCodeContains(Fields13.class, "prototype.value = false;");
+		assertCodeContains(Fields13.class, "prototype._value = false;");
+	}
+
+	@Test
+	public void testNoModifiersFieldExpectedToNotBePublic() {
+		assertCodeContains(Fields25_non_public_prefix.class, "" +
+				"    prototype._packageField = null;\n" +
+				"    prototype._privateField = null;\n" +
+				"    prototype.publicField = null;\n" +
+				"    prototype.getThisPackageField = function() {\n" +
+				"        var myFields25nonpublicprefix = new Fields25_non_public_prefix();\n" +
+				"        myFields25nonpublicprefix._packageField = \"test\";\n" +
+				"        return this._packageField;\n" +
+				"    };\n" +
+				"    prototype.getThisPrivateField = function() {\n" +
+				"        return this._privateField;\n" +
+				"    };\n" +
+				"    prototype.getThisPublicField = function() {\n" +
+				"        return this.publicField;\n" +
+				"    };\n" +
+				"    prototype.getPackageField = function() {\n" +
+				"        return this._packageField;\n" +
+				"    };\n" +
+				"    prototype.getPrivateField = function() {\n" +
+				"        return this._privateField;\n" +
+				"    };\n" +
+				"    prototype.getPublicField = function() {\n" +
+				"        return this.publicField;\n" +
+				"    };\n" +
+				"    constructor.InnerClass = function(parent) {\n" +
+				"        this._parent = parent;\n" +
+				"    };\n" +
+				"    constructor.InnerClass = stjs.extend(constructor.InnerClass, null, [], function(constructor, prototype) {\n" +
+				"        prototype._innerPackageField = null;\n" +
+				"        prototype._innerPrivateField = null;\n" +
+				"        prototype.innerPublicField = null;\n" +
+				"        prototype._parent = null;\n" +
+				"        prototype.getThisPackageField = function() {\n" +
+				"            var myFields25nonpublicprefix = new Fields25_non_public_prefix();\n" +
+				"            myFields25nonpublicprefix._packageField = \"test\";\n" +
+				"            return this._innerPackageField;\n" +
+				"        };\n" +
+				"        prototype.getThisPrivateField = function() {\n" +
+				"            return this._innerPrivateField;\n" +
+				"        };\n" +
+				"        prototype.getThisPublicField = function() {\n" +
+				"            return this.innerPublicField;\n" +
+				"        };\n" +
+				"        prototype.getPackageField = function() {\n" +
+				"            return this._parent._packageField;\n" +
+				"        };\n" +
+				"        prototype.getPrivateField = function() {\n" +
+				"            return this._parent._privateField;\n" +
+				"        };\n" +
+				"        prototype.getPublicField = function() {\n" +
+				"            return this._parent.publicField;\n" +
+				"        };");
 	}
 
 	@Test

--- a/generator/src/test/java/org/stjs/generator/writer/inheritance/InheritanceGeneratorTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/inheritance/InheritanceGeneratorTest.java
@@ -18,7 +18,7 @@ public class InheritanceGeneratorTest extends AbstractStjsTest {
 	@Test
 	public void testAccessProtectedField() {
 		// the this. prefix should be added for fields from the super class too
-		assertCodeContains(Inheritance3.class, "return this.field;");
+		assertCodeContains(Inheritance3.class, "return this._field;");
 	}
 
 	@Test

--- a/generator/src/test/java/org/stjs/generator/writer/inlineFunctions/InlineFunctionGeneratorTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/inlineFunctions/InlineFunctionGeneratorTest.java
@@ -26,7 +26,7 @@ public class InlineFunctionGeneratorTest extends AbstractStjsTest {
 	public void testInterfaceAndParam() {
 		assertCodeContains(InlineFunctions2b.class,
 				"stjs.extend(function InlineFunctions2b$1(){},  null, [FunctionInterface2], function(constructor, prototype){"
-						+ "prototype.test=2; prototype.$invoke=function(arg){arg=arg+1;}");
+						+ "prototype._test=2; prototype.$invoke=function(arg){arg=arg+1;}");
 	}
 
 	@Test

--- a/generator/src/test/java/org/stjs/generator/writer/innerTypes/InnerTypesGeneratorTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/innerTypes/InnerTypesGeneratorTest.java
@@ -123,7 +123,7 @@ public class InnerTypesGeneratorTest extends AbstractStjsTest {
 	public void testEnumInsideInner() {
 		String code = generate(InnerTypes17.class);
 		assertCodeContains(code, "var InnerTypes17 = function(){};" + "InnerTypes17 = stjs.extend(InnerTypes17, null, [], function(constructor, prototype){");
-		assertCodeContains(code, "var deep = InnerTypes17.Inner.Enum.a;");
+		assertCodeContains(code, "var deep = InnerTypes17.Inner._Enum.a;");
 		assertCodeContains(code, "stjs.extend(constructor.Inner, null, [], function(constructor, prototype){");
 		assertCodeContains(code, "constructor.Enum=stjs.enumeration(");
 	}
@@ -150,7 +150,7 @@ public class InnerTypesGeneratorTest extends AbstractStjsTest {
 		assertEquals(2, ((Number) result).intValue());
 
 		assertCodeContains(InnerTypes20.class, "constructor.Holder = function(){};"
-				+ "constructor.Holder = stjs.extend(constructor.Holder, null, [], function(constructor, prototype){" + "       constructor.VALUE = 2;"
+				+ "constructor.Holder = stjs.extend(constructor.Holder, null, [], function(constructor, prototype){" + "       constructor._VALUE = 2;"
 				+ "}, {}, {});");
 	}
 
@@ -163,7 +163,7 @@ public class InnerTypesGeneratorTest extends AbstractStjsTest {
 
 	@Test
 	public void testCallPrivateMethodFromAnonymous() {
-		assertCodeContains(InnerTypes22.class, "return this.privateMethod()");
+		assertCodeContains(InnerTypes22.class, "return this._privateMethod()");
 	}
 
 	@Test

--- a/generator/src/test/java/org/stjs/generator/writer/methods/MethodsGeneratorTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/methods/MethodsGeneratorTest.java
@@ -104,8 +104,8 @@ public class MethodsGeneratorTest extends AbstractStjsTest {
 	public void testAbstractMethod() {
 		// the class only contains abstract methods, therefore nothing must be generated
 		assertCodeContains(Methods15.class, "stjs.extend(Methods15, null, [], function(constructor, prototype){" //
-				+ "prototype.doSomething=function(){};" //
-				+ "prototype.doSomethingElse=function(){};" //
+				+ "prototype._doSomething=function(){};" //
+				+ "prototype._doSomethingElse=function(){};" //
 				+ "}, {}, {});");
 	}
 

--- a/generator/src/test/java/org/stjs/generator/writer/names/NamesGeneratorTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/names/NamesGeneratorTest.java
@@ -27,7 +27,7 @@ public class NamesGeneratorTest extends AbstractStjsTest {
 	@Test
 	public void testSpecialThis() {
 		// the special parameter THIS is no longer changed
-		assertCodeContains(Names5.class, "return THIS.field");
+		assertCodeContains(Names5.class, "return THIS._field");
 	}
 
 	@Test

--- a/generator/src/test/java/org/stjs/generator/writer/operators/OperatorGeneratorTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/operators/OperatorGeneratorTest.java
@@ -11,6 +11,6 @@ public class OperatorGeneratorTest extends AbstractStjsTest {
 
 	@Test
 	public void testBugNot() {
-		assertCodeContains(Operator2.class, "if (!this.func())");
+		assertCodeContains(Operator2.class, "if (!this._func())");
 	}
 }

--- a/generator/src/test/java/org/stjs/generator/writer/statements/StatementsGeneratorTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/statements/StatementsGeneratorTest.java
@@ -108,8 +108,8 @@ public class StatementsGeneratorTest extends AbstractStjsTest {
 	@Test
 	public void testStaticInitializer() {
 		assertCodeContains(Statements14.class, "{" + //
-				"Statements14.instance = new Statements14();" + //
-				"var n = Statements14.instance.method();" + //
+				"Statements14._instance = new Statements14();" + //
+				"var n = Statements14._instance.method();" + //
 				"}");
 	}
 

--- a/generator/src/test/java/org/stjs/generator/writer/variables/VariablesGeneratorTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/variables/VariablesGeneratorTest.java
@@ -29,7 +29,7 @@ public class VariablesGeneratorTest extends AbstractStjsTest {
 
 	@Test
 	public void testKeepDeclarationLocation() {
-		assertCodeContains(Variables5.class, "y = this.x;");
+		assertCodeContains(Variables5.class, "y = this._x;");
 		assertCodeContains(Variables5.class, "k = x;");
 	}
 


### PR DESCRIPTION
We prefix the non-public fields with `_` to follow convention in javascript.
