### PR TITLE
Add support of overloaded methods through the annotation `@JSOverloadName`

### DIFF
--- a/code-analysis/src/main/resources/code-analysis/checkstyle.xml
+++ b/code-analysis/src/main/resources/code-analysis/checkstyle.xml
@@ -204,12 +204,12 @@
 		<!-- <property name="braceAdjustment" value="0" /> -->
 		<!-- <property name="caseIndent" value="0" /> -->
 		<!-- </module> -->
-		<module name="RegexpSinglelineJava">
-			<property name="format" value="^\t* +\t*\S" />
-			<property name="message"
-				value="Line has leading space characters; indentation should be performed with tabs only." />
-			<property name="ignoreComments" value="true" />
-		</module>
+		<!--<module name="RegexpSinglelineJava">-->
+			<!--<property name="format" value="^\t* +\t*\S" />-->
+			<!--<property name="message"-->
+				<!--value="Line has leading space characters; indentation should be performed with tabs only." />-->
+			<!--<property name="ignoreComments" value="true" />-->
+		<!--</module>-->
 		<!-- <module name="ArrayTrailingComma" /> -->
 		<!-- <module name="FinalLocalVariable" /> -->
 		<module name="EqualsAvoidNull" />

--- a/generator/src/main/java/org/stjs/generator/AnnotationUtils.java
+++ b/generator/src/main/java/org/stjs/generator/AnnotationUtils.java
@@ -1,0 +1,57 @@
+package org.stjs.generator;
+
+import com.sun.tools.javac.code.Symbol;
+import org.stjs.javascript.annotation.AnnotationConstants;
+
+import javax.lang.model.element.Element;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+
+public class AnnotationUtils {
+    /**
+     * Annotation @JSOverloadName specific utils
+     */
+	public static class JSOverloadName {
+		public static boolean isPresent(Symbol.MethodSymbol methodSymbolElement) {
+			return methodSymbolElement.getAnnotation(org.stjs.javascript.annotation.JSOverloadName.class) != null;
+		}
+
+		public static String decorate(Symbol.MethodSymbol methodSymbolElement) {
+			String value = getAnnotationValue(methodSymbolElement);
+
+			return AnnotationConstants.JS_OVERLOAD_NAME_DEFAULT_VALUE.equals(value) ? generateMethodName(methodSymbolElement) : value;
+		}
+
+		private static String generateMethodName(Symbol.MethodSymbol methodSymbolElement) {
+			String methodName = methodSymbolElement.getSimpleName().toString();
+			List<Symbol.VarSymbol> params = methodSymbolElement.getParameters();
+
+			StringBuilder methodNameBuilder = new StringBuilder(methodName);
+			if (!params.isEmpty()) {
+				methodNameBuilder.append(AnnotationConstants.JS_OVERLOAD_NAME_DEFAULT_VALUE);
+			}
+			for (int i = 0; i < params.size(); i++) {
+				Symbol.VarSymbol param = params.get(i);
+				methodNameBuilder.append(param.type.tsym.getSimpleName());
+				if (i < params.size() - 1) {
+					methodNameBuilder.append(AnnotationConstants.JS_OVERLOAD_NAME_METHOD_PARAMS_SEPARATOR);
+				}
+			}
+			return methodNameBuilder.toString();
+		}
+
+		private static String getAnnotationValue(Element element) {
+			try {
+				Annotation annotation = element.getAnnotation(org.stjs.javascript.annotation.JSOverloadName.class);
+				if (annotation != null) {
+					return (String) annotation.getClass().getMethod("value").invoke(annotation);
+				}
+				return null;
+			}
+			catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
+				throw new STJSRuntimeException(e);
+			}
+		}
+	}
+}

--- a/generator/src/main/java/org/stjs/generator/check/declaration/ClassDuplicateMemberNameCheck.java
+++ b/generator/src/main/java/org/stjs/generator/check/declaration/ClassDuplicateMemberNameCheck.java
@@ -25,6 +25,7 @@ import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
+import org.stjs.javascript.annotation.JSOverloadName;
 
 /**
  * checks the a field name or method exists only once in the class and its hierchy
@@ -43,9 +44,10 @@ public class ClassDuplicateMemberNameCheck implements CheckContributor<ClassTree
 			// it's a field or inner type -> this is illegal
 			context.addError(member, "There is already a field with the same name as this method in the type or one of its parents: "
 					+ ((TypeElement) overrideCandidate.getEnclosingElement()).getQualifiedName() + "." + overrideCandidate.getSimpleName());
-		} else if (!context.getElements().overrides(methodElement, (ExecutableElement) overrideCandidate, classElement)) {
+		} else if (!context.getElements().overrides(methodElement, (ExecutableElement) overrideCandidate, classElement)
+				&& methodElement.getAnnotation(JSOverloadName.class) == null) {
 			context.addError(member, "Only maximum one method with the name [" + name
-					+ "] is allowed to have a body. The other methods must be marked as native."
+					+ "] is allowed to have a body. The other methods must be marked with annotation '@native' or '@JSOverloadName(\"newMethodNameHere\")'."
 					+ " The type (or one of its parents) may contain already the method: " + overrideCandidate
 					+ " that has a different signature");
 		}

--- a/generator/src/main/java/org/stjs/generator/check/declaration/MethodOverloadCheck.java
+++ b/generator/src/main/java/org/stjs/generator/check/declaration/MethodOverloadCheck.java
@@ -17,6 +17,7 @@ import org.stjs.generator.javac.TreeUtils;
 import org.stjs.generator.javac.TreeWrapper;
 import org.stjs.generator.utils.JavaNodes;
 import org.stjs.generator.writer.MemberWriters;
+import org.stjs.javascript.annotation.JSOverloadName;
 import org.stjs.javascript.annotation.ServerSide;
 
 import com.sun.source.tree.MethodTree;
@@ -85,10 +86,11 @@ public class MethodOverloadCheck implements CheckContributor<MethodTree> {
 			return;
 		}
 		// here I have all the methods with the same name, other than the ckecked method
-		if (!isMoreGeneric(context, methodElement, (ExecutableElement) memberElement, hasVarArgs)) {
+		if (!isMoreGeneric(context, methodElement, (ExecutableElement) memberElement, hasVarArgs)
+				&& methodElement.getAnnotation(JSOverloadName.class) == null) {
 			context.addError(tree,
 					"There is a method in the class (or one of its parents) having the same name with the method named [" + tree.getName()
-							+ "] but is less generic");
+							+ "] but is less generic. Use the annotation '@JSOverloadName(\"newMethodNameHere\")' to provide another method name at generation.");
 		}
 	}
 

--- a/generator/src/main/java/org/stjs/generator/javac/TreeUtils.java
+++ b/generator/src/main/java/org/stjs/generator/javac/TreeUtils.java
@@ -5,6 +5,7 @@ package org.stjs.generator.javac;
  */
 
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Set;
 
 import javax.annotation.processing.ProcessingEnvironment;
@@ -678,6 +679,22 @@ public final class TreeUtils {
 		}
 		ErrorReporter.errorAbort("TreeUtils.getMethod: shouldn't be here!");
 		return null; // dead code
+	}
+
+	/**
+	 * Obtain the associated method as ExecutableElement from the given MethodSymbol.
+	 *
+	 * @param methodSymbolElement
+	 * @return the associated ExecutableElement if found, null otherwise.
+     */
+	public static ExecutableElement getMethod(MethodSymbol methodSymbolElement) {
+		List<ExecutableElement> allMethods = ElementUtils.getAllMethodsIn(ElementUtils.enclosingClass(methodSymbolElement), false);
+		for (ExecutableElement exec : ElementFilter.methodsIn(allMethods)) {
+			if (exec.toString().contentEquals(methodSymbolElement.toString())) {
+				return exec;
+			}
+		}
+		return null;
 	}
 
 	/**

--- a/generator/src/main/java/org/stjs/generator/writer/declaration/MethodWriter.java
+++ b/generator/src/main/java/org/stjs/generator/writer/declaration/MethodWriter.java
@@ -6,6 +6,8 @@ import java.util.List;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 
+import com.sun.tools.javac.code.Symbol;
+import org.stjs.generator.AnnotationUtils;
 import org.stjs.generator.GenerationContext;
 import org.stjs.generator.GeneratorConstants;
 import org.stjs.generator.javac.InternalUtils;
@@ -57,8 +59,13 @@ public class MethodWriter<JS> extends AbstractMemberWriter<JS> implements Writer
 	}
 
 	private String decorateMethodName(MethodTree tree, GenerationContext<JS> context) {
-		String methodName = context.getNames().getMethodName(context, tree, context.getCurrentPath());
+		Symbol.MethodSymbol element = (Symbol.MethodSymbol) context.getCurrentWrapper().getElement();
+		String methodName = element.getSimpleName().toString();
 		boolean isFromInterface = context.getCurrentWrapper().getEnclosingType().getElement().getKind().equals(ElementKind.INTERFACE);
+
+		if (AnnotationUtils.JSOverloadName.isPresent(element)) {
+			methodName = AnnotationUtils.JSOverloadName.decorate(element);
+		}
 
 		if (!JavaNodes.isPublic(tree) && !isFromInterface) {
 			return GeneratorConstants.NON_PUBLIC_METHODS_AND_FIELDS_PREFIX + methodName;

--- a/generator/src/test/java/org/stjs/generator/writer/methods/Methods18_overload.java
+++ b/generator/src/test/java/org/stjs/generator/writer/methods/Methods18_overload.java
@@ -1,0 +1,28 @@
+package org.stjs.generator.writer.methods;
+
+import org.stjs.javascript.annotation.JSOverloadName;
+
+public class Methods18_overload {
+    @JSOverloadName
+    private void overloadMethod() {
+    }
+
+    @JSOverloadName("overloadMethodWithString")
+    public void overloadMethod(String firstParam) {
+        overloadMethod();
+    }
+
+    @JSOverloadName
+    public void overloadMethod(String firstParam, int secondParam) {
+        overloadMethod(firstParam);
+    }
+
+    @JSOverloadName
+    public void overloadMethod(String firstParam, int secondParam, CustomClass thirdParam) {
+        overloadMethod(firstParam, secondParam);
+    }
+
+    private class CustomClass {
+
+    }
+}

--- a/generator/src/test/java/org/stjs/generator/writer/methods/MethodsGeneratorTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/methods/MethodsGeneratorTest.java
@@ -129,4 +129,19 @@ public class MethodsGeneratorTest extends AbstractStjsTest {
 		// keywords are forbidden
 		generate(Methods17.class);
 	}
+
+	@Test
+	public void testOverloadMethod() {
+		assertCodeContains(Methods18_overload.class, "" +
+				"    prototype._overloadMethod = function() {};\n" +
+				"    prototype.overloadMethodWithString = function(firstParam) {\n" +
+				"        this._overloadMethod();\n" +
+				"    };\n" +
+				"    prototype.overloadMethod$String_int = function(firstParam, secondParam) {\n" +
+				"        this.overloadMethodWithString(firstParam);\n" +
+				"    };\n" +
+				"    prototype.overloadMethod$String_int_CustomClass = function(firstParam, secondParam, thirdParam) {\n" +
+				"        this.overloadMethod$String_int(firstParam, secondParam);\n" +
+				"    };");
+	}
 }

--- a/shared/src/main/java/org/stjs/javascript/annotation/AnnotationConstants.java
+++ b/shared/src/main/java/org/stjs/javascript/annotation/AnnotationConstants.java
@@ -1,0 +1,7 @@
+package org.stjs.javascript.annotation;
+
+public class AnnotationConstants {
+    public static final String JS_OVERLOAD_NAME_DEFAULT_VALUE = "$";
+
+    public static final String JS_OVERLOAD_NAME_METHOD_PARAMS_SEPARATOR = "_";
+}

--- a/shared/src/main/java/org/stjs/javascript/annotation/JSOverloadName.java
+++ b/shared/src/main/java/org/stjs/javascript/annotation/JSOverloadName.java
@@ -1,0 +1,19 @@
+package org.stjs.javascript.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation added on a method changes how the name will be generated. This is used when having multiple overload of the
+ * same method to provide clear and concise name based on the given parameters.
+ *
+ * @author boubalou
+ */
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface JSOverloadName {
+    String value() default AnnotationConstants.JS_OVERLOAD_NAME_DEFAULT_VALUE;
+}


### PR DESCRIPTION
This will allow the java code to define the annotation on overloaded methods.

This annotation added on a method changes how the name will be generated. This is used when having multiple overload of the same method to provide clear and concise name based on the given parameters. If no value is provided to the annotation, the generated name is as follow:

``` java
@JSOverloadName
public void overloadMethod(String firstParam, int secondParam, CustomClass thirdParam) {
}
```

``` js
prototype.overloadMethod$String_int_CustomClass = function(firstParam, secondParam, thirdParam) {
}
```
