### PR TITLE
Fix java8 tests for prefixed non-public members

### DIFF
--- a/generator-plugin-java8/src/main/java/org/stjs/generator/plugin/java8/writer/expression/MemberReferenceWriter.java
+++ b/generator-plugin-java8/src/main/java/org/stjs/generator/plugin/java8/writer/expression/MemberReferenceWriter.java
@@ -8,8 +8,10 @@ import java.util.List;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
 
 import org.stjs.generator.GenerationContext;
+import org.stjs.generator.GeneratorConstants;
 import org.stjs.generator.javascript.JavaScriptBuilder;
 import org.stjs.generator.name.DependencyType;
 import org.stjs.generator.utils.JavaNodes;
@@ -47,7 +49,15 @@ public class MemberReferenceWriter<JS> implements WriterContributor<MemberRefere
 		JavaScriptBuilder<JS> js = context.js();
 		Element type = methodElement.getEnclosingElement();
 		JS typeName = js.name(context.getNames().getTypeName(context, type, DependencyType.STATIC));
-		return js.property(typeName, tree.getName());
+		return js.property(typeName, decorateMemberAccessor(tree, methodElement));
+	}
+
+	private String decorateMemberAccessor(MemberReferenceTree tree, ExecutableElement methodElement) {
+		String fieldName = tree.getName().toString();
+		if (!methodElement.getModifiers().contains(Modifier.PUBLIC)) {
+			fieldName = GeneratorConstants.NON_PUBLIC_METHODS_AND_FIELDS_PREFIX + fieldName;
+		}
+		return fieldName;
 	}
 
 	/**
@@ -58,10 +68,10 @@ public class MemberReferenceWriter<JS> implements WriterContributor<MemberRefere
 		Element type = methodElement.getEnclosingElement();
 		JS typeName = js.name(context.getNames().getTypeName(context, type, DependencyType.STATIC));
 		JS proto = js.property(typeName, JavascriptKeywords.PROTOTYPE);
-		JS method = js.property(proto, tree.getName());
-		JS methoCall = js.property(method, "call");
+		JS method = js.property(proto, decorateMemberAccessor(tree, methodElement));
+		JS methodCall = js.property(method, "call");
 		// + 1 because first is the object to which the method is applied
-		JS call = js.functionCall(methoCall, generateArguments(context, methodElement.getParameters().size() + 1));
+		JS call = js.functionCall(methodCall, generateArguments(context, methodElement.getParameters().size() + 1));
 		return js.function(null, Collections.emptyList(), js.returnStatement(call));
 	}
 
@@ -72,7 +82,7 @@ public class MemberReferenceWriter<JS> implements WriterContributor<MemberRefere
 			ExecutableElement methodElement) {
 		JavaScriptBuilder<JS> js = context.js();
 		JS target = visitor.scan(tree.getQualifierExpression(), context);
-		JS methodName = js.string(tree.getName().toString());
+		JS methodName = js.string(decorateMemberAccessor(tree, methodElement));
 		JS stjsBind = context.js().property(context.js().name("stjs"), "bind");
 		return js.functionCall(stjsBind, Arrays.asList(target, methodName));
 	}

--- a/generator-plugin-java8/src/test/java/org/stjs/generator/plugin/java8/writer/lambda/LambdaGeneratorTest.java
+++ b/generator-plugin-java8/src/test/java/org/stjs/generator/plugin/java8/writer/lambda/LambdaGeneratorTest.java
@@ -29,17 +29,17 @@ public class LambdaGeneratorTest extends AbstractStjsTest {
 
 	@Test
 	public void testLambaAccessFieldOuterScope() {
-		assertCodeContains(Lambda5.class, "var c = stjs.bind(this, function() {return this.field + 1;});");
+		assertCodeContains(Lambda5.class, "var c = stjs.bind(this, function() {return this._field + 1;});");
 	}
 
 	@Test
 	public void testLambaAccessQualifiedFieldOuterScope() {
-		assertCodeContains(Lambda5b.class, "var c = stjs.bind(this, function() {return this.field + 1;});");
+		assertCodeContains(Lambda5b.class, "var c = stjs.bind(this, function() {return this._field + 1;});");
 	}
 
 	@Test
 	public void testLambaAccessMethodOuterScope() {
-		assertCodeContains(Lambda6.class, "var c = stjs.bind(this, function() {return this.outerMethod() + 1;});");
+		assertCodeContains(Lambda6.class, "var c = stjs.bind(this, function() {return this._outerMethod() + 1;});");
 	}
 
 	@Test

--- a/generator-plugin-java8/src/test/java/org/stjs/generator/plugin/java8/writer/methodref/MethodReferenceGeneratorTest.java
+++ b/generator-plugin-java8/src/test/java/org/stjs/generator/plugin/java8/writer/methodref/MethodReferenceGeneratorTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 public class MethodReferenceGeneratorTest extends AbstractStjsTest {
 	@Test
 	public void testStaticMethodRef() {
-		assertCodeContains(MethodRef1.class, "calculate(MethodRef1.inc)");
+		assertCodeContains(MethodRef1.class, "_calculate(MethodRef1._inc)");
 		assertEquals(1, ((Number)execute(MethodRef1.class)).intValue());
 	}
 
@@ -39,7 +39,7 @@ public class MethodReferenceGeneratorTest extends AbstractStjsTest {
 
 	@Test
 	public void testUsageOFieldMethodRef() {
-		assertCodeContains(MethodRef6.class, "calculate(stjs.bind(this.field, \"method\"))");
+		assertCodeContains(MethodRef6.class, "calculate(stjs.bind(this._field, \"method\"))");
 	}
 
 	@Test


### PR DESCRIPTION
When I implemented the prefix on non-public members, I forgot to run the other module "java8".
