### PR TITLE
Adjust the overload check

### DIFF
--- a/generator/src/main/java/org/stjs/generator/check/declaration/ClassDuplicateMemberNameCheck.java
+++ b/generator/src/main/java/org/stjs/generator/check/declaration/ClassDuplicateMemberNameCheck.java
@@ -2,16 +2,13 @@ package org.stjs.generator.check.declaration;
 
 import java.util.Collection;
 
-import javax.lang.model.element.Element;
-import javax.lang.model.element.ElementKind;
-import javax.lang.model.element.ExecutableElement;
-import javax.lang.model.element.TypeElement;
-import javax.lang.model.element.VariableElement;
+import javax.lang.model.element.*;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 
 import org.stjs.generator.GenerationContext;
+import org.stjs.generator.GeneratorConstants;
 import org.stjs.generator.check.CheckContributor;
 import org.stjs.generator.check.CheckVisitor;
 import org.stjs.generator.javac.TreeUtils;
@@ -107,15 +104,20 @@ public class ClassDuplicateMemberNameCheck implements CheckContributor<ClassTree
 				return;
 			}
 
-			String name = ((VariableTree) member).getName().toString();
+			VariableTree memberVariableTree = (VariableTree) member;
+			String name = memberVariableTree.getName().toString();
+			if (!memberVariableTree.getModifiers().getFlags().contains(Modifier.PUBLIC)) {
+				name = GeneratorConstants.NON_PUBLIC_METHODS_AND_FIELDS_PREFIX + name;
+			}
+
 			Collection<Element> sameName = existingNames.get(name);
 			if (sameName.isEmpty()) {
-				Element variableElement = TreeUtils.elementFromDeclaration((VariableTree) member);
+				Element variableElement = TreeUtils.elementFromDeclaration(memberVariableTree);
 				existingNames.put(name, variableElement);
 			} else {
 				if (!hasOnlyFields(sameName)) {
 					// accept fields with the same name, but not methods and fields
-					context.addError(member, "The type (or one of its parents) contains already a method called [" + name
+					context.addError(memberVariableTree, "The type (or one of its parents) contains already a method called [" + name
 							+ "]. Javascript cannot distinguish methods/fields with the same name");
 				}
 			}

--- a/generator/src/test/java/org/stjs/generator/writer/fields/Fields26_non_public_prefix.java
+++ b/generator/src/test/java/org/stjs/generator/writer/fields/Fields26_non_public_prefix.java
@@ -1,12 +1,12 @@
 package org.stjs.generator.writer.fields;
 
-public class Fields25_non_public_prefix {
+public class Fields26_non_public_prefix {
     String packageField;
     private String privateField;
     public String publicField;
 
     public String getThisPackageField() {
-        Fields25_non_public_prefix myFields25nonpublicprefix = new Fields25_non_public_prefix();
+        Fields26_non_public_prefix myFields25nonpublicprefix = new Fields26_non_public_prefix();
         myFields25nonpublicprefix.packageField = "test";
 
         return this.packageField;
@@ -36,14 +36,14 @@ public class Fields25_non_public_prefix {
         String innerPackageField;
         private String innerPrivateField;
         public String innerPublicField;
-        private Fields25_non_public_prefix parent;
+        private Fields26_non_public_prefix parent;
 
-        public InnerClass(Fields25_non_public_prefix parent) {
+        public InnerClass(Fields26_non_public_prefix parent) {
             this.parent = parent;
         }
 
         public String getThisPackageField() {
-            Fields25_non_public_prefix myFields25nonpublicprefix = new Fields25_non_public_prefix();
+            Fields26_non_public_prefix myFields25nonpublicprefix = new Fields26_non_public_prefix();
             myFields25nonpublicprefix.packageField = "test";
 
             return this.innerPackageField;

--- a/generator/src/test/java/org/stjs/generator/writer/fields/Fields27_non_public_field_with_public_method.java
+++ b/generator/src/test/java/org/stjs/generator/writer/fields/Fields27_non_public_field_with_public_method.java
@@ -1,0 +1,9 @@
+package org.stjs.generator.writer.fields;
+
+public class Fields27_non_public_field_with_public_method {
+    private int isCool = 0;
+
+    public int isCool() {
+        return isCool;
+    }
+}

--- a/generator/src/test/java/org/stjs/generator/writer/fields/FieldsGeneratorTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/fields/FieldsGeneratorTest.java
@@ -84,13 +84,22 @@ public class FieldsGeneratorTest extends AbstractStjsTest {
 	}
 
 	@Test
+	public void testNonPublicFieldWithPublicMethodOfSameName() {
+		assertCodeContains(Fields27_non_public_field_with_public_method.class, "" +
+				"    prototype._isCool = 0;\n" +
+				"    prototype.isCool = function() {\n" +
+				"        return this._isCool;\n" +
+				"    };");
+	}
+
+	@Test
 	public void testNoModifiersFieldExpectedToNotBePublic() {
-		assertCodeContains(Fields25_non_public_prefix.class, "" +
+		assertCodeContains(Fields26_non_public_prefix.class, "" +
 				"    prototype._packageField = null;\n" +
 				"    prototype._privateField = null;\n" +
 				"    prototype.publicField = null;\n" +
 				"    prototype.getThisPackageField = function() {\n" +
-				"        var myFields25nonpublicprefix = new Fields25_non_public_prefix();\n" +
+				"        var myFields25nonpublicprefix = new Fields26_non_public_prefix();\n" +
 				"        myFields25nonpublicprefix._packageField = \"test\";\n" +
 				"        return this._packageField;\n" +
 				"    };\n" +
@@ -118,7 +127,7 @@ public class FieldsGeneratorTest extends AbstractStjsTest {
 				"        prototype.innerPublicField = null;\n" +
 				"        prototype._parent = null;\n" +
 				"        prototype.getThisPackageField = function() {\n" +
-				"            var myFields25nonpublicprefix = new Fields25_non_public_prefix();\n" +
+				"            var myFields25nonpublicprefix = new Fields26_non_public_prefix();\n" +
 				"            myFields25nonpublicprefix._packageField = \"test\";\n" +
 				"            return this._innerPackageField;\n" +
 				"        };\n" +


### PR DESCRIPTION
The check for duplicate member name wasn't using our decoration pattern to add a prefix on non-public fields.
