### PR TITLE
Add a configuration value so that we can convert synchronized block a…

### DIFF
--- a/generator/src/main/java/org/stjs/generator/GeneratorConfiguration.java
+++ b/generator/src/main/java/org/stjs/generator/GeneratorConfiguration.java
@@ -27,12 +27,13 @@ public class GeneratorConfiguration {
 	private final File targetFolder;
 	private final GenerationDirectory generationFolder;
 	private final ClassResolver classResolver;
+	private final boolean isSynchronizedAllowed;
 
 	// We actually have a builder for that, so the number of parameters warning doesn't apply
 	@SuppressWarnings("PMD.ExcessiveParameterList")
 	GeneratorConfiguration(Collection<String> allowedPackages, Set<String> allowedJavaLangClasses, boolean generateArrayHasOwnProperty,
 			boolean generateSourceMap, String sourceEncoding, Set<String> annotations, ClassLoader stjsClassLoader, File targetFolder,
-			GenerationDirectory generationFolder, ClassResolver classResolver) {
+			GenerationDirectory generationFolder, ClassResolver classResolver, boolean isSynchronizedAllowed) {
 		this.allowedPackages = allowedPackages;
 		this.allowedJavaLangClasses = allowedJavaLangClasses;
 		this.generateArrayHasOwnProperty = generateArrayHasOwnProperty;
@@ -43,6 +44,7 @@ public class GeneratorConfiguration {
 		this.targetFolder = targetFolder;
 		this.generationFolder = generationFolder;
 		this.classResolver = classResolver;
+		this.isSynchronizedAllowed = isSynchronizedAllowed;
 	}
 
 	/**
@@ -91,5 +93,9 @@ public class GeneratorConfiguration {
 
 	public ClassResolver getClassResolver() {
 		return classResolver;
+	}
+
+	public boolean isSynchronizedAllowed() {
+		return isSynchronizedAllowed;
 	}
 }

--- a/generator/src/main/java/org/stjs/generator/GeneratorConfigurationBuilder.java
+++ b/generator/src/main/java/org/stjs/generator/GeneratorConfigurationBuilder.java
@@ -32,6 +32,7 @@ public class GeneratorConfigurationBuilder {
 	private boolean generateArrayHasOwnProperty = true;
 	private boolean generateSourceMap;
 	private String sourceEncoding = Charset.defaultCharset().name();
+	private boolean isSynchronizedAllowed= false;
 	private ClassLoader stjsClassLoader;
 	private File targetFolder;
 	private GenerationDirectory generationFolder;
@@ -55,6 +56,7 @@ public class GeneratorConfigurationBuilder {
 			targetFolder(baseConfig.getTargetFolder());
 			generationFolder(baseConfig.getGenerationFolder());
 			classResolver(baseConfig.getClassResolver());
+			setSynchronizedAllowed(baseConfig.isSynchronizedAllowed());
 		}
 	}
 
@@ -123,6 +125,12 @@ public class GeneratorConfigurationBuilder {
 		return this;
 	}
 
+	public GeneratorConfigurationBuilder setSynchronizedAllowed(boolean synchronizedAllowed) {
+		this.isSynchronizedAllowed = synchronizedAllowed;
+		return this;
+	}
+
+
 	public GeneratorConfiguration build() {
 		allowedJavaLangClasses.add("Object");
 		allowedJavaLangClasses.add("Class");
@@ -159,7 +167,8 @@ public class GeneratorConfigurationBuilder {
 				stjsClassLoader,  //
 				targetFolder,  //
 				generationFolder, //
-				classResolver == null ? new DefaultClassResolver(stjsClassLoader) : classResolver //
+				classResolver == null ? new DefaultClassResolver(stjsClassLoader) : classResolver, //
+				isSynchronizedAllowed //
 		);
 	}
 

--- a/generator/src/main/java/org/stjs/generator/GeneratorConfigurationBuilder.java
+++ b/generator/src/main/java/org/stjs/generator/GeneratorConfigurationBuilder.java
@@ -32,7 +32,7 @@ public class GeneratorConfigurationBuilder {
 	private boolean generateArrayHasOwnProperty = true;
 	private boolean generateSourceMap;
 	private String sourceEncoding = Charset.defaultCharset().name();
-	private boolean isSynchronizedAllowed= false;
+	private boolean isSynchronizedAllowed = false;
 	private ClassLoader stjsClassLoader;
 	private File targetFolder;
 	private GenerationDirectory generationFolder;

--- a/generator/src/main/java/org/stjs/generator/check/declaration/MethodSynchronizedCheck.java
+++ b/generator/src/main/java/org/stjs/generator/check/declaration/MethodSynchronizedCheck.java
@@ -1,6 +1,7 @@
 package org.stjs.generator.check.declaration;
 
-import javax.lang.model.element.Modifier;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.Tree;
 
 import org.stjs.generator.GenerationContext;
 import org.stjs.generator.check.CheckContributor;
@@ -8,26 +9,28 @@ import org.stjs.generator.check.CheckVisitor;
 import org.stjs.generator.javac.TreeWrapper;
 import org.stjs.generator.writer.MemberWriters;
 
-import com.sun.source.tree.MethodTree;
-import com.sun.source.tree.Tree;
+import javax.lang.model.element.Modifier;
 
 /**
  * this class checks that you don't have synchornized methods, as this feature is not supported in JavaScript
+ *
  * @author acraciun
  */
 public class MethodSynchronizedCheck implements CheckContributor<MethodTree> {
 
-	@Override
-	public Void visit(CheckVisitor visitor, MethodTree tree, GenerationContext<Void> context) {
-		TreeWrapper<Tree, Void> tw = context.getCurrentWrapper();
-		if (MemberWriters.shouldSkip(tw)) {
-			return null;
-		}
+    @Override
+    public Void visit(CheckVisitor visitor, MethodTree tree, GenerationContext<Void> context) {
+        TreeWrapper<Tree, Void> tw = context.getCurrentWrapper();
+        if (MemberWriters.shouldSkip(tw)) {
+            return null;
+        }
 
-		if (tree.getModifiers().getFlags().contains(Modifier.SYNCHRONIZED)) {
-			context.addError(tree, "Synchronized methods are not supported by Javascript");
-		}
+        if (!context.getConfiguration().isSynchronizedAllowed()) {
+            if (tree.getModifiers().getFlags().contains(Modifier.SYNCHRONIZED)) {
+                context.addError(tree, "Synchronized methods are not supported by Javascript");
+            }
+        }
 
-		return null;
-	}
+        return null;
+    }
 }

--- a/generator/src/main/java/org/stjs/generator/check/statement/SynchronizedCheck.java
+++ b/generator/src/main/java/org/stjs/generator/check/statement/SynchronizedCheck.java
@@ -15,7 +15,9 @@ public class SynchronizedCheck implements CheckContributor<SynchronizedTree> {
 
 	@Override
 	public Void visit(CheckVisitor visitor, SynchronizedTree tree, GenerationContext<Void> context) {
-		context.addError(tree, "Synchronized blocks are not supported by Javascript");
+		if (!context.getConfiguration().isSynchronizedAllowed()) {
+			context.addError(tree, "Synchronized blocks are not supported by Javascript");
+		}
 		return null;
 	}
 

--- a/generator/src/main/java/org/stjs/generator/writer/statement/SynchronizedWriter.java
+++ b/generator/src/main/java/org/stjs/generator/writer/statement/SynchronizedWriter.java
@@ -15,8 +15,13 @@ public class SynchronizedWriter<JS> implements WriterContributor<SynchronizedTre
 
 	@Override
 	public JS visit(WriterVisitor<JS> visitor, SynchronizedTree tree, GenerationContext<JS> context) {
-		// synchronized is not allowed
-		context.addError(tree, "Synchronized blocks are not allowed");
-		return null;
+		if (context.getConfiguration().isSynchronizedAllowed()) {
+			JS js = visitor.visitBlock(tree.getBlock(), context);
+			return context.withPosition(tree, js);
+		} else {
+			context.addError(tree, "Synchronized blocks are not allowed");
+			return null;
+		}
+
 	}
 }

--- a/generator/src/test/java/org/stjs/generator/writer/methods/Methods16.java
+++ b/generator/src/test/java/org/stjs/generator/writer/methods/Methods16.java
@@ -3,6 +3,9 @@ package org.stjs.generator.writer.methods;
 public class Methods16 {
 
 	public synchronized void method() {
+		for (int i = 0; i < 10; i++) {
+			//
+		}
 	}
 
 }

--- a/generator/src/test/java/org/stjs/generator/writer/methods/MethodsGeneratorTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/methods/MethodsGeneratorTest.java
@@ -119,7 +119,11 @@ public class MethodsGeneratorTest extends AbstractStjsTest {
 	@Test
 	public void testSynchronizedMethod() {
 		GeneratorConfiguration configuration = new GeneratorConfigurationBuilder().setSynchronizedAllowed(true).build();
-		assertCodeContains(Methods16.class, "stjs.extend(Methods16, null, [], function(constructor, prototype){ prototype.method = function() {for (var i = 0; i < 10; i++) {}};}", configuration);
+		assertCodeContains(Methods16.class, "stjs.extend(Methods16, null, [], function(constructor, prototype)" +
+				"{ prototype.method = function() {" +
+				"for (var i = 0; i < 10; i++) {}" +
+				"}" +
+				";}", configuration);
 	}
 
 	@Test(expected = JavascriptFileGenerationException.class)

--- a/generator/src/test/java/org/stjs/generator/writer/methods/MethodsGeneratorTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/methods/MethodsGeneratorTest.java
@@ -1,6 +1,8 @@
 package org.stjs.generator.writer.methods;
 
 import org.junit.Test;
+import org.stjs.generator.GeneratorConfiguration;
+import org.stjs.generator.GeneratorConfigurationBuilder;
 import org.stjs.generator.utils.AbstractStjsTest;
 import org.stjs.generator.JavascriptFileGenerationException;
 
@@ -114,10 +116,10 @@ public class MethodsGeneratorTest extends AbstractStjsTest {
 				+ "}, {}, {});");
 	}
 
-	@Test(expected = JavascriptFileGenerationException.class)
+	@Test
 	public void testSynchronizedMethod() {
-		// synchronized is forbidden
-		generate(Methods16.class);
+		GeneratorConfiguration configuration = new GeneratorConfigurationBuilder().setSynchronizedAllowed(true).build();
+		assertCodeContains(Methods16.class, "stjs.extend(Methods16, null, [], function(constructor, prototype){ prototype.method = function() {for (var i = 0; i < 10; i++) {}};}", configuration);
 	}
 
 	@Test(expected = JavascriptFileGenerationException.class)

--- a/generator/src/test/java/org/stjs/generator/writer/statements/Statements17.java
+++ b/generator/src/test/java/org/stjs/generator/writer/statements/Statements17.java
@@ -4,6 +4,9 @@ public class Statements17 {
 
 	public void method() {
 		synchronized (this) {
+			for (int i = 0; i < 10; ++i) {
+				//
+			}
 		}
 	}
 }

--- a/generator/src/test/java/org/stjs/generator/writer/statements/StatementsGeneratorTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/statements/StatementsGeneratorTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Ignore;
 import org.junit.Test;
+import org.stjs.generator.GeneratorConfiguration;
+import org.stjs.generator.GeneratorConfigurationBuilder;
 import org.stjs.generator.utils.AbstractStjsTest;
 import org.stjs.generator.JavascriptFileGenerationException;
 
@@ -125,10 +127,10 @@ public class StatementsGeneratorTest extends AbstractStjsTest {
 		assertEquals(2, ((Number) execute(Statements16.class)).intValue());
 	}
 
-	@Test(expected = JavascriptFileGenerationException.class)
+	@Test
 	public void testSynchronizedBlock() {
-		// synchronized not supported
-		generate(Statements17.class);
+		GeneratorConfiguration configuration = new GeneratorConfigurationBuilder().setSynchronizedAllowed(true).build();
+		assertCodeContains(Statements17.class, "for (var i = 0; i < 10; ++i) {}", configuration);
 	}
 
 	@Test(expected = JavascriptFileGenerationException.class)


### PR DESCRIPTION
…nd methods

For methods, we simply ignore the synchronized keyword

For blocks, we simply write the content of the block
