### PR TITLE
Fix generation of method with prefix

### DIFF
--- a/generator/src/test/java/org/stjs/generator/writer/fields/Fields31_protected_parent.java
+++ b/generator/src/test/java/org/stjs/generator/writer/fields/Fields31_protected_parent.java
@@ -1,0 +1,19 @@
+package org.stjs.generator.writer.fields;
+
+public class Fields31_protected_parent {
+    protected String getProtectedField() {
+        return "test";
+    }
+
+    private static class InnerClass {
+        private Fields31_protected_parent parent;
+
+        public InnerClass(Fields31_protected_parent parent) {
+            this.parent = parent;
+        }
+
+        public String getProtectedParentMethod() {
+            return parent.getProtectedField();
+        }
+    }
+}

--- a/generator/src/test/java/org/stjs/generator/writer/fields/FieldsGeneratorTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/fields/FieldsGeneratorTest.java
@@ -258,4 +258,9 @@ public class FieldsGeneratorTest extends AbstractStjsTest {
 				"            sum += element[0];\n" +
 				"        }");
 	}
+
+	@Test
+	public void testProtectedMethodInParent() {
+		assertCodeContains(Fields31_protected_parent.class, "return this._parent._getProtectedField();");
+	}
 }


### PR DESCRIPTION
We were missing a use case for protected method from parent.
