### PR TITLE
Fix `stjs.copyProps() and `stjs.copyInexistentProps()`

### DIFF
--- a/client-runtime/src/main/resources/META-INF/resources/webjars/stjs-client-runtime/stjs.js
+++ b/client-runtime/src/main/resources/META-INF/resources/webjars/stjs-client-runtime/stjs.js
@@ -296,7 +296,7 @@ stjs.ns=function(path){
 
 stjs.copyProps=function(from, to){
 	for(var key in from){
-		if (!stjs.skipCopy[key])
+		if (!stjs.skipCopy.hasOwnProperty(key)))
 			to[key]	= from[key];
 	}
 	return to;
@@ -304,7 +304,7 @@ stjs.copyProps=function(from, to){
 
 stjs.copyInexistentProps=function(from, to){
 	for(var key in from){
-		if (!stjs.skipCopy[key] && !to[key])
+		if (!stjs.skipCopy.hasOwnProperty(key)) && !to[key])
 			to[key]	= from[key];
 	}
 	return to;


### PR DESCRIPTION
They weren't accessing the right properties from `stjs.skipCopy` object which was interfering with native properties such as `valueOf()`.
