### PR TITLE
Add the support to re-write overloaded methods in String and Integer type of objects

### DIFF
--- a/client-runtime/src/main/resources/META-INF/resources/webjars/stjs-client-runtime/stjs.js
+++ b/client-runtime/src/main/resources/META-INF/resources/webjars/stjs-client-runtime/stjs.js
@@ -48,12 +48,15 @@ if (!String.prototype.getChars) {
 if (!String.prototype.contentEquals){
 	String.prototype.contentEquals=stjs.NOT_IMPLEMENTED;
 }
-if (!String.prototype.startsWith) {
-	String.prototype.startsWith=function(start, from){
-		var f = from != null ? from : 0;
-		return this.substring(f, f + start.length) == start;
-	}
+
+String.prototype.startsWith$String_int=function(start, from){
+    return this.substring(from, from + start.length) == start;
 }
+
+String.prototype.startsWith$String=function(start) {
+    return this.startsWith$String_int(start, 0);
+}
+
 if (!String.prototype.endsWith) {
 	String.prototype.endsWith=function(end){
 		if (end == null)
@@ -126,21 +129,24 @@ if (!String.prototype.replaceFirst){
 	}
 }
 
-if (!String.prototype.regionMatches){
-	String.prototype.regionMatches=function(ignoreCase, toffset, other, ooffset, len){
-		if (arguments.length == 4){
-			len=arguments[3];
-			ooffset=arguments[2];
-			other=arguments[1];
-			toffset=arguments[0];
-			ignoreCase=false;
-		}
-		if (toffset < 0 || ooffset < 0 || other == null || toffset + len > this.length || ooffset + len > other.length)
-			return false;
-		var s1 = this.substring(toffset, toffset + len);
-		var s2 = other.substring(ooffset, ooffset + len);
-		return ignoreCase ? s1.equalsIgnoreCase(s2) : s1 === s2;
-	}
+String.prototype.indexOf$String=function(str) {
+    return this.indexOf(str) >= 0;
+}
+
+String.prototype.indexOf$String_int=stjs.NOT_IMPLEMENTED;
+String.prototype.indexOf$int=stjs.NOT_IMPLEMENTED;
+String.prototype.indexOf$int_int=stjs.NOT_IMPLEMENTED;
+
+String.prototype.regionMatches$boolean_int_String_int_int=function(ignoreCase, toffset, other, ooffset, len) {
+    if (toffset < 0 || ooffset < 0 || other == null || toffset + len > this.length || ooffset + len > other.length)
+        return false;
+    var s1 = this.substring(toffset, toffset + len);
+    var s2 = other.substring(ooffset, ooffset + len);
+    return ignoreCase ? s1.equalsIgnoreCase(s2) : s1 === s2;
+}
+
+String.prototype.regionMatches$int_String_int_int=function(toffset, other, ooffset, len) {
+    return this.regionMatches$boolean_int_String_int_int(true, toffset, other, ooffset, len);
 }
 
 if(!String.prototype.contains){
@@ -152,7 +158,6 @@ if(!String.prototype.contains){
 if(!String.prototype.getClass){
 	String.prototype.getClass=stjs.JavalikeGetClass;
 }
-
 
 //force valueof to match the Java's behavior
 String.valueOf=function(value){
@@ -166,6 +171,26 @@ var Float=Number;
 var Integer=Number;
 var Long=Number;
 var Short=Number;
+
+Number.parseInt$String=function(str) {
+    return parseInt(str);
+}
+
+Number.parseInt$String_int=function(str, radix) {
+    return parseInt(str, radix);
+}
+
+Number.valueOf$String=function(str) {
+    return Number.valueOf(Number.parseInt$String(str));
+}
+
+Number.valueOf$int=function(value) {
+    return Number.valueOf(value);
+}
+
+Number.valueOf$String_int=function(str, radix) {
+    return Number.valueOf(Number.parseInt$String_int(str, radix));
+}
 
 /* type conversion - approximative as Javascript only has integers and doubles */
 if (!Number.prototype.intValue) {

--- a/generator/src/main/java/org/stjs/generator/javac/TreeUtils.java
+++ b/generator/src/main/java/org/stjs/generator/javac/TreeUtils.java
@@ -687,7 +687,7 @@ public final class TreeUtils {
 	 * @param methodSymbolElement
 	 * @return the associated ExecutableElement if found, null otherwise.
      */
-	public static ExecutableElement getMethod(MethodSymbol methodSymbolElement) {
+	public static ExecutableElement getMethod(Element methodSymbolElement) {
 		List<ExecutableElement> allMethods = ElementUtils.getAllMethodsIn(ElementUtils.enclosingClass(methodSymbolElement), false);
 		for (ExecutableElement exec : ElementFilter.methodsIn(allMethods)) {
 			if (exec.toString().contentEquals(methodSymbolElement.toString())) {

--- a/generator/src/test/java/org/stjs/generator/lib/number/Number4_overloaded_methods.java
+++ b/generator/src/test/java/org/stjs/generator/lib/number/Number4_overloaded_methods.java
@@ -1,0 +1,8 @@
+package org.stjs.generator.lib.number;
+
+public class Number4_overloaded_methods {
+    public static void main(String[] args) {
+        int test = Integer.parseInt("test");
+        int testRadix = Integer.parseInt("test", 10);
+    }
+}

--- a/generator/src/test/java/org/stjs/generator/lib/number/NumberMethodsTest.java
+++ b/generator/src/test/java/org/stjs/generator/lib/number/NumberMethodsTest.java
@@ -1,9 +1,9 @@
 package org.stjs.generator.lib.number;
 
-import static org.junit.Assert.assertEquals;
-
 import org.junit.Test;
 import org.stjs.generator.utils.AbstractStjsTest;
+
+import static org.junit.Assert.assertEquals;
 
 public class NumberMethodsTest extends AbstractStjsTest {
 
@@ -20,5 +20,12 @@ public class NumberMethodsTest extends AbstractStjsTest {
 	@Test
 	public void testValueOf() {
 		assertEquals(123.0, executeAndReturnNumber(Number3.class), 0);
+	}
+
+	@Test
+	public void testIntegerOverloadMethodNames() {
+		assertCodeContains(Number4_overloaded_methods.class, "" +
+				"        var test = Integer.parseInt$String(\"test\");\n" +
+				"        var testRadix = Integer.parseInt$String_int(\"test\", 10);\n");
 	}
 }

--- a/generator/src/test/java/org/stjs/generator/lib/string/String14_overloaded_methods.java
+++ b/generator/src/test/java/org/stjs/generator/lib/string/String14_overloaded_methods.java
@@ -1,0 +1,15 @@
+package org.stjs.generator.lib.string;
+
+public class String14_overloaded_methods {
+    public static void main(String[] args) {
+        String test = "abcd";
+
+        test.regionMatches(false, 1, "bc", 0, 2);
+        test.regionMatches(1, "bc", 0, 2);
+
+        test.indexOf("ab");
+        test.indexOf("ab", 0);
+        test.indexOf(1);
+        test.indexOf(1, 0);
+    }
+}

--- a/generator/src/test/java/org/stjs/generator/lib/string/StringMethodsTest.java
+++ b/generator/src/test/java/org/stjs/generator/lib/string/StringMethodsTest.java
@@ -1,9 +1,9 @@
 package org.stjs.generator.lib.string;
 
-import static org.junit.Assert.assertEquals;
-
 import org.junit.Test;
 import org.stjs.generator.utils.AbstractStjsTest;
+
+import static org.junit.Assert.assertEquals;
 
 public class StringMethodsTest extends AbstractStjsTest {
 
@@ -70,5 +70,16 @@ public class StringMethodsTest extends AbstractStjsTest {
 	@Test
 	public void testRegionMatchesIgnoreCase() {
 		assertEquals(true, execute(String13.class));
+	}
+
+	@Test
+	public void testStringOverloadMethodNames() {
+		assertCodeContains(String14_overloaded_methods.class, "" +
+				"        test.regionMatches$boolean_int_String_int_int(false, 1, \"bc\", 0, 2);\n" +
+				"        test.regionMatches$int_String_int_int(1, \"bc\", 0, 2);\n" +
+				"        test.indexOf$String(\"ab\");\n" +
+				"        test.indexOf$String_int(\"ab\", 0);\n" +
+				"        test.indexOf$int(1);\n" +
+				"        test.indexOf$int_int(1, 0);");
 	}
 }

--- a/generator/src/test/java/org/stjs/generator/writer/methods/Methods25_overload_string_getBytes.java
+++ b/generator/src/test/java/org/stjs/generator/writer/methods/Methods25_overload_string_getBytes.java
@@ -1,0 +1,9 @@
+package org.stjs.generator.writer.methods;
+
+import java.io.UnsupportedEncodingException;
+
+public class Methods25_overload_string_getBytes {
+    public void getBytes() throws UnsupportedEncodingException {
+        byte[] bytes = "test".getBytes("UTF-8");
+    }
+}

--- a/generator/src/test/java/org/stjs/generator/writer/methods/MethodsGeneratorTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/methods/MethodsGeneratorTest.java
@@ -204,6 +204,12 @@ public class MethodsGeneratorTest extends AbstractStjsTest {
 		testForbiddenConfiguration(expectedForbiddenMethod, Methods24_forbidden_configuration_overloaded_method.class);
 	}
 
+	@Test
+	public void testOverloadMethodWithBytes() {
+		assertCodeContains(Methods25_overload_string_getBytes.class, "" +
+				"        var bytes = \"test\".getBytes$String(\"UTF-8\");\n");
+	}
+
 	private void testForbiddenConfiguration(String expectedForbiddenMethod, Class<?> clazz) {
 		Set<String> forbiddenMethodInvocations = new HashSet<>();
 		forbiddenMethodInvocations.add(expectedForbiddenMethod);

--- a/generator/src/test/java/org/stjs/generator/writer/specialMethods/SpecialMethodGeneratorTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/specialMethods/SpecialMethodGeneratorTest.java
@@ -152,7 +152,7 @@ public class SpecialMethodGeneratorTest extends AbstractStjsTest {
 	@Test
 	public void testCastArray() {
 		// Array<V> x = $castArray(obj[]) -> var x = obj;
-		assertCodeContains(SpecialMethod19.class, "var a = (\"abc\".split(\",\"));");
+		assertCodeContains(SpecialMethod19.class, "var a = (\"abc\".split$String(\",\"));");
 	}
 
 	@Test


### PR DESCRIPTION
This allow us to provide a specific implementation and avoid overriding a prototype with a semi valid implementation of the expected method that has multiple params.
