### PR TITLE
Support configuration for namespaces in the generator

### DIFF
--- a/generator/src/main/java/org/stjs/generator/GeneratorConfiguration.java
+++ b/generator/src/main/java/org/stjs/generator/GeneratorConfiguration.java
@@ -14,12 +14,14 @@ package org.stjs.generator;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.Map;
 
 public class GeneratorConfiguration {
 	private final Collection<String> allowedPackages;
 	private final Collection<String> allowedJavaLangClasses;
 	private final Collection<String> forbiddenMethodInvocations;
 	private final Collection<String> annotations;
+	private final Map<String, String> namespaces;
 	private final boolean generateArrayHasOwnProperty;
 	private final boolean generateSourceMap;
 	private final String sourceEncoding;
@@ -32,13 +34,14 @@ public class GeneratorConfiguration {
 	// We actually have a builder for that, so the number of parameters warning doesn't apply
 	@SuppressWarnings("PMD.ExcessiveParameterList")
 	GeneratorConfiguration(Collection<String> allowedPackages, Collection<String> allowedJavaLangClasses,
-						   Collection<String> forbiddenMethodInvocations, boolean generateArrayHasOwnProperty,
-						   boolean generateSourceMap, String sourceEncoding, Collection<String> annotations,
-						   ClassLoader stjsClassLoader,	File targetFolder, GenerationDirectory generationFolder,
-						   ClassResolver classResolver, boolean isSynchronizedAllowed) {
+						   Collection<String> forbiddenMethodInvocations, Map<String, String> namespaces,
+						   boolean generateArrayHasOwnProperty, boolean generateSourceMap, String sourceEncoding,
+						   Collection<String> annotations, ClassLoader stjsClassLoader, File targetFolder,
+						   GenerationDirectory generationFolder, ClassResolver classResolver, boolean isSynchronizedAllowed) {
 		this.allowedPackages = allowedPackages;
 		this.allowedJavaLangClasses = allowedJavaLangClasses;
 		this.forbiddenMethodInvocations = forbiddenMethodInvocations;
+		this.namespaces = namespaces;
 		this.generateArrayHasOwnProperty = generateArrayHasOwnProperty;
 		this.generateSourceMap = generateSourceMap;
 		this.sourceEncoding = sourceEncoding;
@@ -64,6 +67,10 @@ public class GeneratorConfiguration {
 
 	public Collection<String> getForbiddenMethodInvocations() {
 		return forbiddenMethodInvocations;
+	}
+
+	public Map<String, String> getNamespaces() {
+		return namespaces;
 	}
 
 	public boolean isGenerateArrayHasOwnProperty() {

--- a/generator/src/main/java/org/stjs/generator/GeneratorConfigurationBuilder.java
+++ b/generator/src/main/java/org/stjs/generator/GeneratorConfigurationBuilder.java
@@ -16,8 +16,10 @@ import java.io.File;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Map;
 
 /**
  * Use this class to build a configuration needed by the {@link Generator}
@@ -29,6 +31,7 @@ public class GeneratorConfigurationBuilder {
 	private final Collection<String> allowedJavaLangClasses = new HashSet<>();
 	private final Collection<String> annotations = new HashSet<>();
 	private final Collection<String> forbiddenMethodInvocations = new HashSet<>();
+	private final Map<String, String> namespaces = new HashMap<>();
 	private boolean generateArrayHasOwnProperty = true;
 	private boolean generateSourceMap;
 	private String sourceEncoding = Charset.defaultCharset().name();
@@ -49,6 +52,7 @@ public class GeneratorConfigurationBuilder {
 			allowedPackages(baseConfig.getAllowedPackages());
 			allowedJavaLangClasses(baseConfig.getAllowedJavaLangClasses());
 			forbiddenMethodInvocations(baseConfig.getForbiddenMethodInvocations());
+			namespaces(baseConfig.getNamespaces());
 			annotations(baseConfig.getAnnotations());
 			generateArrayHasOwnProperty(baseConfig.isGenerateArrayHasOwnProperty());
 			generateSourceMap(baseConfig.isGenerateSourceMap());
@@ -88,6 +92,11 @@ public class GeneratorConfigurationBuilder {
 
 	public GeneratorConfigurationBuilder forbiddenMethodInvocations(Collection<String> methodInvocations) {
 		forbiddenMethodInvocations.addAll(methodInvocations);
+		return this;
+	}
+
+	public GeneratorConfigurationBuilder namespaces(Map<String, String> namespacesMap) {
+		namespaces.putAll(namespacesMap);
 		return this;
 	}
 
@@ -174,6 +183,7 @@ public class GeneratorConfigurationBuilder {
 				allowedPackages,  //
 				allowedJavaLangClasses, //
 				forbiddenMethodInvocations, //
+				namespaces, //
 				generateArrayHasOwnProperty, //
 				generateSourceMap, //
 				sourceEncoding,  //

--- a/generator/src/main/java/org/stjs/generator/javac/TreeWrapper.java
+++ b/generator/src/main/java/org/stjs/generator/javac/TreeWrapper.java
@@ -1,16 +1,11 @@
 package org.stjs.generator.javac;
 
-import java.lang.annotation.Annotation;
-import java.util.Set;
-import javax.annotation.Nonnull;
-import javax.lang.model.element.Element;
-import javax.lang.model.element.ElementKind;
-import javax.lang.model.element.Modifier;
-import javax.lang.model.element.PackageElement;
-import javax.lang.model.element.TypeElement;
-import javax.lang.model.type.TypeMirror;
-
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.util.TreePath;
 import org.stjs.generator.GenerationContext;
+import org.stjs.generator.GeneratorConfiguration;
 import org.stjs.generator.GeneratorConstants;
 import org.stjs.generator.NamespaceUtil;
 import org.stjs.generator.name.DependencyType;
@@ -23,10 +18,16 @@ import org.stjs.javascript.annotation.ServerSide;
 import org.stjs.javascript.annotation.SyntheticType;
 import org.stjs.javascript.annotation.Template;
 
-import com.sun.source.tree.ClassTree;
-import com.sun.source.tree.IdentifierTree;
-import com.sun.source.tree.Tree;
-import com.sun.source.util.TreePath;
+import javax.annotation.Nonnull;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+import java.lang.annotation.Annotation;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * this class is a wrapper around a {@link Tree} node to give you easier access to the most important methods of the
@@ -162,6 +163,15 @@ public class TreeWrapper<T extends Tree, JS> {
 		if (nsAnnotation != null) {
 			return nsAnnotation.value();
 		}
+		GeneratorConfiguration configuration = context.getConfiguration();
+		Map<String, String> namespacesFromConfig = configuration.getNamespaces();
+		for (Map.Entry<String, String> entry : namespacesFromConfig.entrySet()) {
+			String key = entry.getKey();
+			if (key != null && key.equals(element.asType().toString())) {
+				return entry.getValue();
+			}
+		}
+
 		return null;
 	}
 

--- a/generator/src/test/java/org/stjs/generator/writer/namespace/Namespace13_generator_configuration.java
+++ b/generator/src/test/java/org/stjs/generator/writer/namespace/Namespace13_generator_configuration.java
@@ -1,0 +1,10 @@
+package org.stjs.generator.writer.namespace;
+
+import java.util.Date;
+
+public class Namespace13_generator_configuration {
+
+    public void main() {
+        Date date = new Date();
+    }
+}

--- a/generator/src/test/java/org/stjs/generator/writer/namespace/NamespaceGeneratorTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/namespace/NamespaceGeneratorTest.java
@@ -1,10 +1,15 @@
 package org.stjs.generator.writer.namespace;
 
 import org.junit.Test;
-import org.stjs.generator.utils.AbstractStjsTest;
+import org.stjs.generator.GeneratorConfigurationBuilder;
 import org.stjs.generator.JavascriptFileGenerationException;
+import org.stjs.generator.utils.AbstractStjsTest;
 import org.stjs.generator.writer.namespace.packageLevel.PackageNamespace1;
 import org.stjs.generator.writer.namespace.packageLevel.empty.deep.PackageNamespace2;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 public class NamespaceGeneratorTest extends AbstractStjsTest {
 	@Test
@@ -62,8 +67,7 @@ public class NamespaceGeneratorTest extends AbstractStjsTest {
 		assertCodeContains(Namespace8.class, "stjs.extend(function Namespace8$1(){a.b.Namespace8.call(this);}, a.b.Namespace8, [], ");
 	}
 
-	@Test(
-			expected = JavascriptFileGenerationException.class)
+	@Test(expected = JavascriptFileGenerationException.class)
 	public void testReservedWordsInNamespace() {
 		generate(Namespace9.class);
 	}
@@ -73,23 +77,47 @@ public class NamespaceGeneratorTest extends AbstractStjsTest {
 		assertCodeContains(PackageNamespace1.class, "a.b.PackageNamespace1 = function()");
 	}
 
-	@Test()
+	@Test
 	public void testAnnotationAtPackageLevelRecursive(){
 		assertCodeContains(PackageNamespace2.class, "a.b.PackageNamespace2 = function()");
 	}
 
-	@Test()
+	@Test
 	public void testNamespaceWithFullyQualifiedStaticMethodName(){
 		assertCodeContains(Namespace10.class, "a.b.Namespace1.staticMethod()");
 	}
 
-	@Test()
+	@Test
 	public void testNamespaceWithStaticMethodInAnotherClass(){
 		assertCodeContains(Namespace11.class, "a.b.Namespace1.staticMethod()");
 	}
 
-	@Test()
+	@Test
 	public void testNamespaceWithStaticMethodInAnotherClassAndStaticImport(){
 		assertCodeContains(Namespace12.class, "a.b.Namespace1.staticMethod()");
+	}
+
+	@Test
+	public void testNamespaceDefinedInConfiguration() {
+		String datePackage = Date.class.getCanonicalName();
+		Map<String, String> namespaces = new HashMap<>();
+		namespaces.put(datePackage, "java_util_custom_namespace");
+		// Test starts with package name
+		namespaces.put("org.stjs.generator.writer", "my.own.namespace");
+
+		GeneratorConfigurationBuilder generatorConfigurationBuilder = new GeneratorConfigurationBuilder();
+		generatorConfigurationBuilder.namespaces(namespaces);
+		generatorConfigurationBuilder.allowedPackage(datePackage);
+
+		assertCodeContains(Namespace13_generator_configuration.class, "" +
+						"stjs.ns(\"my.own.namespace\");\n" +
+						"my.own.namespace.Namespace13_generator_configuration = function(outerClass$0) {\n" +
+						"    this._outerClass$0 = outerClass$0;\n" +
+						"};\n" +
+						"my.own.namespace.Namespace13_generator_configuration = stjs.extend(my.own.namespace.Namespace13_generator_configuration, null, [], function(constructor, prototype) {",
+				generatorConfigurationBuilder.build());
+		assertCodeContains(Namespace13_generator_configuration.class, "" +
+						"var date = new java_util_custom_namespace.Date(this);",
+				generatorConfigurationBuilder.build());
 	}
 }


### PR DESCRIPTION
You can now provide a map of `<string, string>` in the configuration like so:

``` java
namespaces = ['java.util': 'stjs.Java']
```
