### PR TITLE
Overloaded names: change TypeVars parameters to output `Object` instead of the `T` or `E`

### DIFF
--- a/generator/src/main/java/org/stjs/generator/javac/InternalUtils.java
+++ b/generator/src/main/java/org/stjs/generator/javac/InternalUtils.java
@@ -454,7 +454,11 @@ public final class InternalUtils {
 		}
 		for (int i = 0; i < params.size(); i++) {
 			Symbol.VarSymbol param = params.get(i);
-			builder.append(param.type.tsym.getSimpleName());
+			String paramName = param.type.tsym.getSimpleName().toString();
+			if (TypeKind.TYPEVAR.equals(param.type.getKind())) {
+				paramName = AnnotationConstants.JS_OVERLOAD_NAME_TYPEVAR_PARAM_NAME;
+			}
+			builder.append(paramName);
 			if (TypeKind.ARRAY.equals(param.type.getKind())) {
 				builder.append(AnnotationConstants.JS_OVERLOAD_NAME_DEFAULT_VALUE);
 

--- a/generator/src/test/java/org/stjs/generator/writer/methods/Methods26_overload_with_generics.java
+++ b/generator/src/test/java/org/stjs/generator/writer/methods/Methods26_overload_with_generics.java
@@ -1,0 +1,10 @@
+package org.stjs.generator.writer.methods;
+
+public class Methods26_overload_with_generics<E> {
+    public void overloadMethod(E firstParam) {
+    }
+
+    public void overloadMethod(E firstParam, int secondParam) {
+        overloadMethod(firstParam);
+    }
+}

--- a/generator/src/test/java/org/stjs/generator/writer/methods/MethodsGeneratorTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/methods/MethodsGeneratorTest.java
@@ -210,6 +210,15 @@ public class MethodsGeneratorTest extends AbstractStjsTest {
 				"        var bytes = \"test\".getBytes$String(\"UTF-8\");\n");
 	}
 
+	@Test
+	public void testOverloadWithGenerics() {
+		assertCodeContains(Methods26_overload_with_generics.class, "" +
+				"    prototype.overloadMethod$Object = function(firstParam) {};\n" +
+				"    prototype.overloadMethod$Object_int = function(firstParam, secondParam) {\n" +
+				"        this.overloadMethod$Object(firstParam);\n" +
+				"    };");
+	}
+
 	private void testForbiddenConfiguration(String expectedForbiddenMethod, Class<?> clazz) {
 		Set<String> forbiddenMethodInvocations = new HashSet<>();
 		forbiddenMethodInvocations.add(expectedForbiddenMethod);

--- a/shared/src/main/java/org/stjs/javascript/annotation/AnnotationConstants.java
+++ b/shared/src/main/java/org/stjs/javascript/annotation/AnnotationConstants.java
@@ -4,4 +4,6 @@ public class AnnotationConstants {
     public static final String JS_OVERLOAD_NAME_DEFAULT_VALUE = "$";
 
     public static final String JS_OVERLOAD_NAME_METHOD_PARAMS_SEPARATOR = "_";
+
+    public static final String JS_OVERLOAD_NAME_TYPEVAR_PARAM_NAME = "Object";
 }


### PR DESCRIPTION
Rock on!
