### PR TITLE
Feature/overloaded methods in sub classes

### DIFF
--- a/generator/src/main/java/org/stjs/generator/AnnotationUtils.java
+++ b/generator/src/main/java/org/stjs/generator/AnnotationUtils.java
@@ -5,39 +5,36 @@ import org.stjs.generator.javac.InternalUtils;
 import org.stjs.javascript.annotation.AnnotationConstants;
 
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.VariableElement;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class AnnotationUtils {
+
     /**
      * Annotation @JSOverloadName specific utils
      */
 	public static class JSOverloadName {
-		public static boolean isPresent(Symbol.MethodSymbol methodSymbolElement) {
-			return methodSymbolElement.getAnnotation(org.stjs.javascript.annotation.JSOverloadName.class) != null;
-		}
 
-		public static String decorate(Symbol.MethodSymbol methodSymbolElement) {
-			String value = getAnnotationValue(methodSymbolElement);
-
-			if (value == null || AnnotationConstants.JS_OVERLOAD_NAME_DEFAULT_VALUE.equals(value)) {
-				String methodName = methodSymbolElement.getSimpleName().toString();
-				List<Symbol.VarSymbol> params = methodSymbolElement.getParameters();
-
-				return InternalUtils.generateOverloadedMethodName(methodName, params);
-			} else {
-				return value;
-			}
-		}
-
-		private static String getAnnotationValue(Element element) {
+		public static String getAnnotationValue(GenerationContext<?> context, ExecutableElement element) {
+			String value = null;
 			try {
 				Annotation annotation = element.getAnnotation(org.stjs.javascript.annotation.JSOverloadName.class);
 				if (annotation != null) {
-					return (String) annotation.getClass().getMethod("value").invoke(annotation);
+					value = (String) annotation.getClass().getMethod("value").invoke(annotation);
+
+					if (AnnotationConstants.JS_OVERLOAD_NAME_DEFAULT_VALUE.equals(value)) {
+						// generate method name with argument types
+						List<? extends VariableElement> params = element.getParameters();
+						value = InternalUtils.generateOverloadedMethodName(context, element.getSimpleName().toString(), params);
+					}
 				}
-				return null;
+
+				return value;
 			}
 			catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
 				throw new STJSRuntimeException(e);

--- a/generator/src/main/java/org/stjs/generator/check/declaration/MethodOverloadManyToSingleCheck.java
+++ b/generator/src/main/java/org/stjs/generator/check/declaration/MethodOverloadManyToSingleCheck.java
@@ -2,6 +2,7 @@ package org.stjs.generator.check.declaration;
 
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
+import org.stjs.generator.AnnotationUtils;
 import org.stjs.generator.GenerationContext;
 import org.stjs.generator.check.CheckContributor;
 import org.stjs.generator.check.CheckVisitor;
@@ -61,7 +62,7 @@ public class MethodOverloadManyToSingleCheck implements CheckContributor<MethodT
         List<? extends Element> allMembers = context.getElements().getAllMembers(superClassElement);
 
         if (ElementUtils.hasAnOverloadedEquivalentMethod(methodElement, allMembers)
-                && (superClassElement.getAnnotation(JSOverloadName.class) == null)) {
+                && (!AnnotationUtils.JSOverloadName.isPresent(methodElement))) {
             context.addError(tree, "There is a method in a parent having the same name [" + tree.getName() + "]"
                     + " than your overloaded method but your class only implement one, which leads to not being overloaded."
                     + " This will lead to a clash in the invocation of the method. "

--- a/generator/src/main/java/org/stjs/generator/check/expression/MethodInvocationConfigurationForbiddenCheck.java
+++ b/generator/src/main/java/org/stjs/generator/check/expression/MethodInvocationConfigurationForbiddenCheck.java
@@ -29,7 +29,7 @@ public class MethodInvocationConfigurationForbiddenCheck implements CheckContrib
 			return null;
 		}
 
-		String transpiledMethodName = MethodInvocationWriter.buildMethodName(tree, context);
+		String transpiledMethodName = context.getNames().getMethodName(context, tree);
 
 		String methodFullPath = ((Symbol.ClassSymbol) methodOwner).className() + "." + transpiledMethodName;
 

--- a/generator/src/main/java/org/stjs/generator/check/expression/MethodInvocationSuperSynthCheck.java
+++ b/generator/src/main/java/org/stjs/generator/check/expression/MethodInvocationSuperSynthCheck.java
@@ -23,7 +23,7 @@ import com.sun.source.tree.Tree;
 public class MethodInvocationSuperSynthCheck implements CheckContributor<MethodInvocationTree> {
 
 	private boolean checkSuperConstructor(MethodInvocationTree tree, GenerationContext<Void> context) {
-		String name = MethodInvocationWriter.buildMethodName(tree, context);
+		String name = context.getNames().getMethodName(context, tree);
 		if (GeneratorConstants.SUPER.equals(name)) {
 			if (!InternalUtils.isSyntheticConstructor(TreeUtils.enclosingOfKind(context.getCurrentPath(), Tree.Kind.METHOD))) {
 				context.addError(tree, "You cannot call the super constructor if that belongs to a @SyntheticType");

--- a/generator/src/main/java/org/stjs/generator/javac/ElementUtils.java
+++ b/generator/src/main/java/org/stjs/generator/javac/ElementUtils.java
@@ -368,6 +368,26 @@ public final class ElementUtils {
 		return similar;
 	}
 
+	public static List<ExecutableElement> getSameMethodsFromSupertypes(TypeElement clazz, ExecutableElement model) {
+		List<ExecutableElement> similar = new ArrayList<ExecutableElement>();
+
+		List<TypeElement> superTypes = ElementUtils.getSuperTypes(clazz);
+		for (TypeElement superType : superTypes) {
+
+			List<ExecutableElement> allMethods = ElementFilter.methodsIn(superType.getEnclosedElements());
+			for (ExecutableElement method : allMethods) {
+				if (sameSignature(model, method)) {
+					similar.add(method);
+				}
+			}
+
+			similar.addAll(getSameMethodsFromSupertypes(superType, model));
+		}
+
+
+		return similar;
+	}
+
 	public static boolean isTypeKind(Element elem) {
 		return elem.getKind().isClass() || elem.getKind().isInterface();
 	}
@@ -401,6 +421,7 @@ public final class ElementUtils {
 		return false;
 	}
 
+
 	public static boolean isConstructor(Element element) {
 		if (!(element instanceof Symbol.MethodSymbol)) {
 			return false;
@@ -432,4 +453,5 @@ public final class ElementUtils {
 		}
 		return methodElement.getAnnotation(JSOverloadName.class) == null;
 	}
+
 }

--- a/generator/src/main/java/org/stjs/generator/javac/InternalUtils.java
+++ b/generator/src/main/java/org/stjs/generator/javac/InternalUtils.java
@@ -21,6 +21,7 @@ import com.sun.tools.javac.tree.JCTree.JCMethodInvocation;
 import com.sun.tools.javac.tree.JCTree.JCNewClass;
 import com.sun.tools.javac.tree.TreeInfo;
 import com.sun.tools.javac.util.Context;
+import org.stjs.generator.GenerationContext;
 import org.stjs.generator.GeneratorConstants;
 import org.stjs.javascript.annotation.AnnotationConstants;
 
@@ -29,6 +30,8 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.WildcardType;
@@ -44,432 +47,436 @@ import java.util.List;
  * of Sun javac internals; any procedure in the Checker Framework that uses a non-public API should be placed here.
  */
 @edu.umd.cs.findbugs.annotations.SuppressWarnings(
-		justification = "copied code", value = "BC_UNCONFIRMED_CAST")
+        justification = "copied code", value = "BC_UNCONFIRMED_CAST")
 @SuppressWarnings("PMD")
 // CHECKSTYLE:OFF
 public final class InternalUtils {
 
-	// Class cannot be instantiated.
-	private InternalUtils() {
-		throw new AssertionError("Class InternalUtils cannot be instantiated.");
-	}
+    // Class cannot be instantiated.
+    private InternalUtils() {
+        throw new AssertionError("Class InternalUtils cannot be instantiated.");
+    }
 
-	/**
-	 * Gets the {@link Element} ("symbol") for the given Tree API node.
-	 * 
-	 * @param tree
-	 *            the {@link Tree} node to get the symbol for
-	 * @throws IllegalArgumentException
-	 *             if {@code tree} is null or is not a valid javac-internal tree (JCTree)
-	 * @return the {@code {@link Symbol} for the given tree, or null if one could not be found
-	 */
-	public static/* @Nullable */Element symbol(/* @Nullable */Tree tree) {
-		if (tree == null) {
-			ErrorReporter.errorAbort("InternalUtils.symbol: tree is null");
-			return null; // dead code
-		}
+    /**
+     * Gets the {@link Element} ("symbol") for the given Tree API node.
+     *
+     * @param tree the {@link Tree} node to get the symbol for
+     * @return the {@code {@link Symbol} for the given tree, or null if one could not be found
+     * @throws IllegalArgumentException if {@code tree} is null or is not a valid javac-internal tree (JCTree)
+     */
+    public static/* @Nullable */Element symbol(/* @Nullable */Tree tree) {
+        if (tree == null) {
+            ErrorReporter.errorAbort("InternalUtils.symbol: tree is null");
+            return null; // dead code
+        }
 
-		if (!(tree instanceof JCTree)) {
-			ErrorReporter.errorAbort("InternalUtils.symbol: tree is not a valid Javac tree");
-			return null; // dead code
-		}
+        if (!(tree instanceof JCTree)) {
+            ErrorReporter.errorAbort("InternalUtils.symbol: tree is not a valid Javac tree");
+            return null; // dead code
+        }
 
-		if (TreeUtils.isExpressionTree(tree)) {
-			tree = TreeUtils.skipParens((ExpressionTree) tree);
-		}
+        if (TreeUtils.isExpressionTree(tree)) {
+            tree = TreeUtils.skipParens((ExpressionTree) tree);
+        }
 
-		switch (tree.getKind()) {
-		case VARIABLE:
-		case METHOD:
-		case CLASS:
+        switch (tree.getKind()) {
+            case VARIABLE:
+            case METHOD:
+            case CLASS:
 
-		case TYPE_PARAMETER:
-			return TreeInfo.symbolFor((JCTree) tree);
+            case TYPE_PARAMETER:
+                return TreeInfo.symbolFor((JCTree) tree);
 
-			// symbol() only works on MethodSelects, so we need to get it manually
-			// for method invocations.
-		case METHOD_INVOCATION:
-			return TreeInfo.symbol(((JCMethodInvocation) tree).getMethodSelect());
+            // symbol() only works on MethodSelects, so we need to get it manually
+            // for method invocations.
+            case METHOD_INVOCATION:
+                return TreeInfo.symbol(((JCMethodInvocation) tree).getMethodSelect());
 
-		case ASSIGNMENT:
-			return TreeInfo.symbol((JCTree) ((AssignmentTree) tree).getVariable());
+            case ASSIGNMENT:
+                return TreeInfo.symbol((JCTree) ((AssignmentTree) tree).getVariable());
 
-		case ARRAY_ACCESS:
-			return symbol(((ArrayAccessTree) tree).getExpression());
+            case ARRAY_ACCESS:
+                return symbol(((ArrayAccessTree) tree).getExpression());
 
-		case NEW_CLASS:
-			return ((JCNewClass) tree).constructor;
+            case NEW_CLASS:
+                return ((JCNewClass) tree).constructor;
 
-		default:
-			if (tree.getKind().toString().equals("ENUM") || tree.getKind().toString().equals("INTERFACE")
-					|| tree.getKind().toString().equals("ANNOTATION_TYPE")) {
-				// java 7 & 8
-				// case ENUM:
-				// case INTERFACE:
-				// case ANNOTATION_TYPE:
-				return TreeInfo.symbolFor((JCTree) tree);
-			}
+            default:
+                if (tree.getKind().toString().equals("ENUM") || tree.getKind().toString().equals("INTERFACE")
+                        || tree.getKind().toString().equals("ANNOTATION_TYPE")) {
+                    // java 7 & 8
+                    // case ENUM:
+                    // case INTERFACE:
+                    // case ANNOTATION_TYPE:
+                    return TreeInfo.symbolFor((JCTree) tree);
+                }
 
-			return TreeInfo.symbol((JCTree) tree);
-		}
-	}
+                return TreeInfo.symbol((JCTree) tree);
+        }
+    }
 
-	/**
-	 * Determines whether or not the node referred to by the given {@link com.sun.source.util.TreePath} is an anonymous
-	 * constructor (the constructor for an anonymous class.
-	 * 
-	 * @param method
-	 *            the {@link com.sun.source.util.TreePath} for a node that may be an anonymous constructor
-	 * @return true if the given path points to an anonymous constructor, false if it does not
-	 */
-	public static boolean isAnonymousConstructor(final MethodTree method) {
-		/* @Nullable */Element e = InternalUtils.symbol(method);
-		if (e == null || !(e instanceof Symbol)) {
-			return false;
-		}
+    /**
+     * Determines whether or not the node referred to by the given {@link com.sun.source.util.TreePath} is an anonymous
+     * constructor (the constructor for an anonymous class.
+     *
+     * @param method the {@link com.sun.source.util.TreePath} for a node that may be an anonymous constructor
+     * @return true if the given path points to an anonymous constructor, false if it does not
+     */
+    public static boolean isAnonymousConstructor(final MethodTree method) {
+        /* @Nullable */
+        Element e = InternalUtils.symbol(method);
+        if (e == null || !(e instanceof Symbol)) {
+            return false;
+        }
 
-		if ((((/* @NonNull */Symbol) e).flags() & Flags.ANONCONSTR) != 0) {
-			return true;
-		}
+        if ((((/* @NonNull */Symbol) e).flags() & Flags.ANONCONSTR) != 0) {
+            return true;
+        }
 
-		return false;
-	}
+        return false;
+    }
 
-	/**
-	 * indicates whether it should return the constructor that gets invoked in cases of anonymous classes
-	 */
-	private static final boolean RETURN_INVOKE_CONSTRUCTOR = true;
+    /**
+     * indicates whether it should return the constructor that gets invoked in cases of anonymous classes
+     */
+    private static final boolean RETURN_INVOKE_CONSTRUCTOR = true;
 
-	/**
-	 * Determines the symbol for a constructor given an invocation via {@code new}. If the tree is a declaration of an
-	 * anonymous class, then method returns constructor that gets invoked in the extended class, rather than the
-	 * anonymous constructor implicitly added by the constructor (JLS 15.9.5.1)
-	 * 
-	 * @param tree
-	 *            the constructor invocation
-	 * @return the {@link ExecutableElement} corresponding to the constructor call in {@code tree}
-	 */
-	public static ExecutableElement constructor(NewClassTree tree) {
+    /**
+     * Determines the symbol for a constructor given an invocation via {@code new}. If the tree is a declaration of an
+     * anonymous class, then method returns constructor that gets invoked in the extended class, rather than the
+     * anonymous constructor implicitly added by the constructor (JLS 15.9.5.1)
+     *
+     * @param tree the constructor invocation
+     * @return the {@link ExecutableElement} corresponding to the constructor call in {@code tree}
+     */
+    public static ExecutableElement constructor(NewClassTree tree) {
 
-		if (!(tree instanceof JCTree.JCNewClass)) {
-			ErrorReporter.errorAbort("InternalUtils.constructor: not a javac internal tree");
-			return null; // dead code
-		}
+        if (!(tree instanceof JCTree.JCNewClass)) {
+            ErrorReporter.errorAbort("InternalUtils.constructor: not a javac internal tree");
+            return null; // dead code
+        }
 
-		JCNewClass newClassTree = (JCNewClass) tree;
+        JCNewClass newClassTree = (JCNewClass) tree;
 
-		if (RETURN_INVOKE_CONSTRUCTOR && tree.getClassBody() != null) {
-			// anonymous constructor bodies should contain exactly one statement
-			// in the form:
-			// super(arg1, ...)
-			// or
-			// o.super(arg1, ...)
-			//
-			// which is a method invocation (!) to the actual constructor
+        if (RETURN_INVOKE_CONSTRUCTOR && tree.getClassBody() != null) {
+            // anonymous constructor bodies should contain exactly one statement
+            // in the form:
+            // super(arg1, ...)
+            // or
+            // o.super(arg1, ...)
+            //
+            // which is a method invocation (!) to the actual constructor
 
-			// the method call is guaranteed to return nonnull
-			JCMethodDecl anonConstructor = (JCMethodDecl) TreeInfo.declarationFor(newClassTree.constructor, newClassTree);
-			assert anonConstructor != null;
-			assert anonConstructor.body.stats.size() == 1;
-			JCExpressionStatement stmt = (JCExpressionStatement) anonConstructor.body.stats.head;
-			JCTree.JCMethodInvocation superInvok = (JCMethodInvocation) stmt.expr;
-			return (ExecutableElement) TreeInfo.symbol(superInvok.meth);
-		}
+            // the method call is guaranteed to return nonnull
+            JCMethodDecl anonConstructor = (JCMethodDecl) TreeInfo.declarationFor(newClassTree.constructor, newClassTree);
+            assert anonConstructor != null;
+            assert anonConstructor.body.stats.size() == 1;
+            JCExpressionStatement stmt = (JCExpressionStatement) anonConstructor.body.stats.head;
+            JCTree.JCMethodInvocation superInvok = (JCMethodInvocation) stmt.expr;
+            return (ExecutableElement) TreeInfo.symbol(superInvok.meth);
+        }
 
-		Element e = newClassTree.constructor;
+        Element e = newClassTree.constructor;
 
-		assert e instanceof ExecutableElement;
+        assert e instanceof ExecutableElement;
 
-		return (ExecutableElement) e;
-	}
+        return (ExecutableElement) e;
+    }
 
-	// public final static List<AnnotationMirror> annotationsFromTypeAnnotationTrees(List<? extends AnnotationTree>
-	// annos) {
-	// List<AnnotationMirror> annotations = new ArrayList<AnnotationMirror>(annos.size());
-	// for (AnnotationTree anno : annos) {
-	// annotations.add(((JCAnnotation) anno).attribute);
-	// }
-	// return annotations;
-	// }
-	//
-	// public final static List<? extends AnnotationMirror> annotationsFromTree(AnnotatedTypeTree node) {
-	// return annotationsFromTypeAnnotationTrees(((JCAnnotatedType) node).annotations);
-	// }
-	//
-	// public final static List<? extends AnnotationMirror> annotationsFromTree(TypeParameterTree node) {
-	// return annotationsFromTypeAnnotationTrees(((JCTypeParameter) node).annotations);
-	// }
-	//
-	// public final static List<? extends AnnotationMirror> annotationsFromArrayCreation(NewArrayTree node, int level) {
-	//
-	// assert node instanceof JCNewArray;
-	// final JCNewArray newArray = ((JCNewArray) node);
-	//
-	// if (level == -1) {
-	// return annotationsFromTypeAnnotationTrees(newArray.annotations);
-	// }
-	//
-	// if (newArray.dimAnnotations.length() > 0 && (level >= 0) && (level < newArray.dimAnnotations.size())) {
-	// return annotationsFromTypeAnnotationTrees(newArray.dimAnnotations.get(level));
-	// }
-	//
-	// return Collections.emptyList();
-	// }
+    // public final static List<AnnotationMirror> annotationsFromTypeAnnotationTrees(List<? extends AnnotationTree>
+    // annos) {
+    // List<AnnotationMirror> annotations = new ArrayList<AnnotationMirror>(annos.size());
+    // for (AnnotationTree anno : annos) {
+    // annotations.add(((JCAnnotation) anno).attribute);
+    // }
+    // return annotations;
+    // }
+    //
+    // public final static List<? extends AnnotationMirror> annotationsFromTree(AnnotatedTypeTree node) {
+    // return annotationsFromTypeAnnotationTrees(((JCAnnotatedType) node).annotations);
+    // }
+    //
+    // public final static List<? extends AnnotationMirror> annotationsFromTree(TypeParameterTree node) {
+    // return annotationsFromTypeAnnotationTrees(((JCTypeParameter) node).annotations);
+    // }
+    //
+    // public final static List<? extends AnnotationMirror> annotationsFromArrayCreation(NewArrayTree node, int level) {
+    //
+    // assert node instanceof JCNewArray;
+    // final JCNewArray newArray = ((JCNewArray) node);
+    //
+    // if (level == -1) {
+    // return annotationsFromTypeAnnotationTrees(newArray.annotations);
+    // }
+    //
+    // if (newArray.dimAnnotations.length() > 0 && (level >= 0) && (level < newArray.dimAnnotations.size())) {
+    // return annotationsFromTypeAnnotationTrees(newArray.dimAnnotations.get(level));
+    // }
+    //
+    // return Collections.emptyList();
+    // }
 
-	public static TypeMirror typeOf(Tree tree) {
-		return ((JCTree) tree).type;
-	}
+    public static TypeMirror typeOf(Tree tree) {
+        return ((JCTree) tree).type;
+    }
 
-	/**
-	 * Returns whether a TypeVariable represents a captured type.
-	 */
-	// public static boolean isCaptured(TypeVariable typeVar) {
-	// return ((Type.TypeVar) typeVar).isCaptured();
-	// }
+    /**
+     * Returns whether a TypeVariable represents a captured type.
+     */
+    // public static boolean isCaptured(TypeVariable typeVar) {
+    // return ((Type.TypeVar) typeVar).isCaptured();
+    // }
 
-	/**
-	 * Returns whether a TypeMirror represents a class type.
-	 */
-	public static boolean isClassType(TypeMirror type) {
-		return type instanceof Type.ClassType;
-	}
+    /**
+     * Returns whether a TypeMirror represents a class type.
+     */
+    public static boolean isClassType(TypeMirror type) {
+        return type instanceof Type.ClassType;
+    }
 
-	/**
-	 * Returns the least upper bound of two {@link TypeMirror}s.
-	 * 
-	 * @param processingEnv
-	 *            The {@link ProcessingEnvironment} to use.
-	 * @param tm1
-	 *            A {@link TypeMirror}.
-	 * @param tm2
-	 *            A {@link TypeMirror}.
-	 * @return The least upper bound of {@code tm1} and {@code tm2}.
-	 */
-	public static TypeMirror leastUpperBound(ProcessingEnvironment processingEnv, TypeMirror tm1, TypeMirror tm2) {
-		Type t1 = (Type) tm1;
-		Type t2 = (Type) tm2;
-		JavacProcessingEnvironment javacEnv = (JavacProcessingEnvironment) processingEnv;
-		Types types = Types.instance(javacEnv.getContext());
-		if (types.isSameType(t1, t2)) {
-			// Special case if the two types are equal.
-			return t1;
-		}
-		// Handle the 'null' type manually (not done by types.lub).
-		if (t1.getKind() == TypeKind.NULL) {
-			return t2;
-		}
-		if (t2.getKind() == TypeKind.NULL) {
-			return t1;
-		}
-		// Special case for primitives.
-		if (TypesUtils.isPrimitive(t1) || TypesUtils.isPrimitive(t2)) {
-			if (types.isAssignable(t1, t2)) {
-				return t2;
-			} else if (types.isAssignable(t2, t1)) {
-				return t1;
-			} else {
-				return processingEnv.getTypeUtils().getNoType(TypeKind.NONE);
-			}
-		}
-		if (t1.getKind() == TypeKind.WILDCARD) {
-			WildcardType wc1 = (WildcardType) t1;
-			Type bound = (Type) wc1.getExtendsBound();
-			if (bound == null) {
-				// Implicit upper bound of java.lang.Object
-				Elements elements = processingEnv.getElementUtils();
-				return elements.getTypeElement("java.lang.Object").asType();
-			}
-			t1 = bound;
-		}
-		if (t2.getKind() == TypeKind.WILDCARD) {
-			WildcardType wc2 = (WildcardType) t2;
-			Type bound = (Type) wc2.getExtendsBound();
-			if (bound == null) {
-				// Implicit upper bound of java.lang.Object
-				Elements elements = processingEnv.getElementUtils();
-				return elements.getTypeElement("java.lang.Object").asType();
-			}
-			t2 = bound;
-		}
-		return types.lub(t1, t2);
-	}
+    /**
+     * Returns the least upper bound of two {@link TypeMirror}s.
+     *
+     * @param processingEnv The {@link ProcessingEnvironment} to use.
+     * @param tm1           A {@link TypeMirror}.
+     * @param tm2           A {@link TypeMirror}.
+     * @return The least upper bound of {@code tm1} and {@code tm2}.
+     */
+    public static TypeMirror leastUpperBound(ProcessingEnvironment processingEnv, TypeMirror tm1, TypeMirror tm2) {
+        Type t1 = (Type) tm1;
+        Type t2 = (Type) tm2;
+        JavacProcessingEnvironment javacEnv = (JavacProcessingEnvironment) processingEnv;
+        Types types = Types.instance(javacEnv.getContext());
+        if (types.isSameType(t1, t2)) {
+            // Special case if the two types are equal.
+            return t1;
+        }
+        // Handle the 'null' type manually (not done by types.lub).
+        if (t1.getKind() == TypeKind.NULL) {
+            return t2;
+        }
+        if (t2.getKind() == TypeKind.NULL) {
+            return t1;
+        }
+        // Special case for primitives.
+        if (TypesUtils.isPrimitive(t1) || TypesUtils.isPrimitive(t2)) {
+            if (types.isAssignable(t1, t2)) {
+                return t2;
+            } else if (types.isAssignable(t2, t1)) {
+                return t1;
+            } else {
+                return processingEnv.getTypeUtils().getNoType(TypeKind.NONE);
+            }
+        }
+        if (t1.getKind() == TypeKind.WILDCARD) {
+            WildcardType wc1 = (WildcardType) t1;
+            Type bound = (Type) wc1.getExtendsBound();
+            if (bound == null) {
+                // Implicit upper bound of java.lang.Object
+                Elements elements = processingEnv.getElementUtils();
+                return elements.getTypeElement("java.lang.Object").asType();
+            }
+            t1 = bound;
+        }
+        if (t2.getKind() == TypeKind.WILDCARD) {
+            WildcardType wc2 = (WildcardType) t2;
+            Type bound = (Type) wc2.getExtendsBound();
+            if (bound == null) {
+                // Implicit upper bound of java.lang.Object
+                Elements elements = processingEnv.getElementUtils();
+                return elements.getTypeElement("java.lang.Object").asType();
+            }
+            t2 = bound;
+        }
+        return types.lub(t1, t2);
+    }
 
-	/**
-	 * Returns the greatest lower bound of two {@link TypeMirror}s.
-	 * 
-	 * @param processingEnv
-	 *            The {@link ProcessingEnvironment} to use.
-	 * @param tm1
-	 *            A {@link TypeMirror}.
-	 * @param tm2
-	 *            A {@link TypeMirror}.
-	 * @return The greatest lower bound of {@code tm1} and {@code tm2}.
-	 */
-	public static TypeMirror greatestLowerBound(ProcessingEnvironment processingEnv, TypeMirror tm1, TypeMirror tm2) {
-		Type t1 = (Type) tm1;
-		Type t2 = (Type) tm2;
-		JavacProcessingEnvironment javacEnv = (JavacProcessingEnvironment) processingEnv;
-		Types types = Types.instance(javacEnv.getContext());
-		if (types.isSameType(t1, t2)) {
-			// Special case if the two types are equal.
-			return t1;
-		}
-		// Handle the 'null' type manually.
-		if (t1.getKind() == TypeKind.NULL) {
-			return t1;
-		}
-		if (t2.getKind() == TypeKind.NULL) {
-			return t2;
-		}
-		// Special case for primitives.
-		if (TypesUtils.isPrimitive(t1) || TypesUtils.isPrimitive(t2)) {
-			if (types.isAssignable(t1, t2)) {
-				return t1;
-			} else if (types.isAssignable(t2, t1)) {
-				return t2;
-			} else {
-				// Javac types.glb returns TypeKind.Error when the GLB does
-				// not exist, but we can't create one. Use TypeKind.NONE
-				// instead.
-				return processingEnv.getTypeUtils().getNoType(TypeKind.NONE);
-			}
-		}
-		if (t1.getKind() == TypeKind.WILDCARD) {
-			return t2;
-		}
-		if (t2.getKind() == TypeKind.WILDCARD) {
-			return t1;
-		}
-		return types.glb(t1, t2);
-	}
+    /**
+     * Returns the greatest lower bound of two {@link TypeMirror}s.
+     *
+     * @param processingEnv The {@link ProcessingEnvironment} to use.
+     * @param tm1           A {@link TypeMirror}.
+     * @param tm2           A {@link TypeMirror}.
+     * @return The greatest lower bound of {@code tm1} and {@code tm2}.
+     */
+    public static TypeMirror greatestLowerBound(ProcessingEnvironment processingEnv, TypeMirror tm1, TypeMirror tm2) {
+        Type t1 = (Type) tm1;
+        Type t2 = (Type) tm2;
+        JavacProcessingEnvironment javacEnv = (JavacProcessingEnvironment) processingEnv;
+        Types types = Types.instance(javacEnv.getContext());
+        if (types.isSameType(t1, t2)) {
+            // Special case if the two types are equal.
+            return t1;
+        }
+        // Handle the 'null' type manually.
+        if (t1.getKind() == TypeKind.NULL) {
+            return t1;
+        }
+        if (t2.getKind() == TypeKind.NULL) {
+            return t2;
+        }
+        // Special case for primitives.
+        if (TypesUtils.isPrimitive(t1) || TypesUtils.isPrimitive(t2)) {
+            if (types.isAssignable(t1, t2)) {
+                return t1;
+            } else if (types.isAssignable(t2, t1)) {
+                return t2;
+            } else {
+                // Javac types.glb returns TypeKind.Error when the GLB does
+                // not exist, but we can't create one. Use TypeKind.NONE
+                // instead.
+                return processingEnv.getTypeUtils().getNoType(TypeKind.NONE);
+            }
+        }
+        if (t1.getKind() == TypeKind.WILDCARD) {
+            return t2;
+        }
+        if (t2.getKind() == TypeKind.WILDCARD) {
+            return t1;
+        }
+        return types.glb(t1, t2);
+    }
 
-	/**
-	 * Returns the return type of a method, where the "raw" return type of that method is given (i.e., the return type
-	 * might still contain unsubstituted type variables), given the receiver of the method call.
-	 */
-	public static TypeMirror substituteMethodReturnType(TypeMirror methodType, TypeMirror substitutedReceiverType) {
-		if (methodType.getKind() != TypeKind.TYPEVAR) {
-			return methodType;
-		}
-		// TODO: find a nicer way to substitute type variables
-		String t = methodType.toString();
-		Type finalReceiverType = (Type) substitutedReceiverType;
-		int i = 0;
-		for (TypeSymbol typeParam : finalReceiverType.tsym.getTypeParameters()) {
-			if (t.equals(typeParam.toString())) {
-				return finalReceiverType.getTypeArguments().get(i);
-			}
-			i++;
-		}
-		assert false;
-		return null;
-	}
+    /**
+     * Returns the return type of a method, where the "raw" return type of that method is given (i.e., the return type
+     * might still contain unsubstituted type variables), given the receiver of the method call.
+     */
+    public static TypeMirror substituteMethodReturnType(TypeMirror methodType, TypeMirror substitutedReceiverType) {
+        if (methodType.getKind() != TypeKind.TYPEVAR) {
+            return methodType;
+        }
+        // TODO: find a nicer way to substitute type variables
+        String t = methodType.toString();
+        Type finalReceiverType = (Type) substitutedReceiverType;
+        int i = 0;
+        for (TypeSymbol typeParam : finalReceiverType.tsym.getTypeParameters()) {
+            if (t.equals(typeParam.toString())) {
+                return finalReceiverType.getTypeArguments().get(i);
+            }
+            i++;
+        }
+        assert false;
+        return null;
+    }
 
-	/**
-	 * Helper function to extract the javac Context from the javac processing environment.
-	 * 
-	 * @param env
-	 *            the processing environment
-	 * @return the javac Context
-	 */
-	public static Context getJavacContext(ProcessingEnvironment env) {
-		return ((JavacProcessingEnvironment) env).getContext();
-	}
+    /**
+     * Helper function to extract the javac Context from the javac processing environment.
+     *
+     * @param env the processing environment
+     * @return the javac Context
+     */
+    public static Context getJavacContext(ProcessingEnvironment env) {
+        return ((JavacProcessingEnvironment) env).getContext();
+    }
 
-	/**
-	 * @param element
-	 * @return Type$1 for inner types
-	 */
-	public static String getSimpleName(Element element) {
-		if (element.getSimpleName().length() != 0) {
-			return element.getSimpleName().toString();
-		}
+    /**
+     * @param element
+     * @return Type$1 for inner types
+     */
+    public static String getSimpleName(Element element) {
+        if (element.getSimpleName().length() != 0) {
+            return element.getSimpleName().toString();
+        }
 
-		// take the binary name for anonymous classes
-		PackageElement pack = ElementUtils.enclosingPackage(element);
-		String packageName = pack != null && !pack.isUnnamed() ? pack.getQualifiedName().toString() : "";
+        // take the binary name for anonymous classes
+        PackageElement pack = ElementUtils.enclosingPackage(element);
+        String packageName = pack != null && !pack.isUnnamed() ? pack.getQualifiedName().toString() : "";
 
-		if (element instanceof ClassSymbol) {
-			return ((ClassSymbol) element).flatName().toString().substring(packageName.length() + 1);
-		}
-		return null;
-	}
+        if (element instanceof ClassSymbol) {
+            return ((ClassSymbol) element).flatName().toString().substring(packageName.length() + 1);
+        }
+        return null;
+    }
 
-	/**
-	 * @param tree
-	 * @return true if the node is a vararg
-	 */
-	public static boolean isVarArg(Tree tree) {
-		if (!(tree instanceof VariableTree)) {
-			return false;
-		}
+    /**
+     * @param tree
+     * @return true if the node is a vararg
+     */
+    public static boolean isVarArg(Tree tree) {
+        if (!(tree instanceof VariableTree)) {
+            return false;
+        }
 
-		/* @Nullable */Element e = InternalUtils.symbol(tree);
-		if (e == null || !(e instanceof Symbol)) {
-			return false;
-		}
+		/* @Nullable */
+        Element e = InternalUtils.symbol(tree);
+        if (e == null || !(e instanceof Symbol)) {
+            return false;
+        }
 
-		if ((((/* @NonNull */Symbol) e).flags() & Flags.VARARGS) != 0) {
-			return true;
-		}
-		return false;
-	}
+        if ((((/* @NonNull */Symbol) e).flags() & Flags.VARARGS) != 0) {
+            return true;
+        }
+        return false;
+    }
 
-	public static boolean isSynthetic(Tree tree) {
+    public static boolean isSynthetic(Tree tree) {
 
-		/* @Nullable */Element e = InternalUtils.symbol(tree);
-		if (e == null || !(e instanceof Symbol)) {
-			return false;
-		}
+		/* @Nullable */
+        Element e = InternalUtils.symbol(tree);
+        if (e == null || !(e instanceof Symbol)) {
+            return false;
+        }
 
-		if ((((/* @NonNull */Symbol) e).flags() & Flags.GENERATEDCONSTR) != 0) {
-			return true;
-		}
-		return false;
-	}
+        if ((((/* @NonNull */Symbol) e).flags() & Flags.GENERATEDCONSTR) != 0) {
+            return true;
+        }
+        return false;
+    }
 
-	public static boolean isSyntheticConstructor(Tree tree) {
-		Element e = InternalUtils.symbol(tree);
-		if (e == null || e.getKind() != ElementKind.CONSTRUCTOR) {
-			return false;
-		}
-		return isSynthetic(tree);
-	}
+    public static boolean isSyntheticConstructor(Tree tree) {
+        Element e = InternalUtils.symbol(tree);
+        if (e == null || e.getKind() != ElementKind.CONSTRUCTOR) {
+            return false;
+        }
+        return isSynthetic(tree);
+    }
 
-	public static String generateOverloadedMethodName(String methodName, List<Symbol.VarSymbol> params) {
-		StringBuilder methodNameBuilder = new StringBuilder(methodName);
+    public static String generateOverloadedMethodName(GenerationContext context, String methodName, List<? extends VariableElement> params) {
+        StringBuilder methodNameBuilder = new StringBuilder(methodName);
 
-		return buildOverloadedName(methodNameBuilder, params);
-	}
+        return buildOverloadedName(context, methodNameBuilder, params);
+    }
 
-	public static String generateOverloadeConstructorName(List<Symbol.VarSymbol> params) {
-		StringBuilder methodNameBuilder = new StringBuilder(GeneratorConstants.MULTIPLE_CONSTRUCTORS_PREFIX);
+    public static String generateOverloadeConstructorName(GenerationContext context, List<? extends VariableElement> params) {
+        StringBuilder methodNameBuilder = new StringBuilder(GeneratorConstants.MULTIPLE_CONSTRUCTORS_PREFIX);
 
-		return buildOverloadedName(methodNameBuilder, params);
-	}
+        return buildOverloadedName(context, methodNameBuilder, params);
+    }
 
-	private static String buildOverloadedName(StringBuilder builder, List<Symbol.VarSymbol> params) {
-		if (!params.isEmpty()) {
-			builder.append(AnnotationConstants.JS_OVERLOAD_NAME_DEFAULT_VALUE);
-		}
-		for (int i = 0; i < params.size(); i++) {
-			Symbol.VarSymbol param = params.get(i);
-			String paramName = param.type.tsym.getSimpleName().toString();
-			if (TypeKind.TYPEVAR.equals(param.type.getKind())) {
-				paramName = AnnotationConstants.JS_OVERLOAD_NAME_TYPEVAR_PARAM_NAME;
-			}
-			builder.append(paramName);
-			if (TypeKind.ARRAY.equals(param.type.getKind())) {
-				builder.append(AnnotationConstants.JS_OVERLOAD_NAME_DEFAULT_VALUE);
+    private static String buildOverloadedName(GenerationContext context, StringBuilder builder, List<? extends Element> params) {
+        for (int i = 0; i < params.size(); i++) {
+            Element param = params.get(i);
 
-				assert param.type instanceof Type.ArrayType;
-				builder.append(((Type.ArrayType) param.type).elemtype.tsym.getSimpleName());
-			}
-			if (i < params.size() - 1) {
-				builder.append(AnnotationConstants.JS_OVERLOAD_NAME_METHOD_PARAMS_SEPARATOR);
-			}
-		}
-		return builder.toString();
-	}
+            if (i == 0) {
+                builder.append(AnnotationConstants.JS_OVERLOAD_NAME_DEFAULT_VALUE);
+            } else {
+                builder.append(AnnotationConstants.JS_OVERLOAD_NAME_METHOD_PARAMS_SEPARATOR);
+            }
+
+            TypeMirror typeMirror = context.getTypes().erasure(param.asType());
+
+            if (TypesUtils.isPrimitive(typeMirror)) {
+                builder.append(typeMirror.toString());
+            } else if (typeMirror.getKind() == TypeKind.ARRAY) {
+                builder.append("Array");
+                builder.append(AnnotationConstants.JS_OVERLOAD_NAME_DEFAULT_VALUE);
+
+                Type.ArrayType arrayType = (Type.ArrayType) typeMirror;
+
+                String typeName = arrayType.elemtype.toString();
+                TypeElement typeElement = context.getElements().getTypeElement(typeName);
+                if (typeElement != null) {
+                    typeName = typeElement.getSimpleName().toString();
+                }
+                builder.append(typeName);
+            } else {
+                TypeElement typeElement = context.getElements().getTypeElement(typeMirror.toString());
+                builder.append(typeElement.getSimpleName().toString());
+            }
+        }
+        return builder.toString();
+    }
+
 }
+
 // CHECKSTYLE:ON

--- a/generator/src/main/java/org/stjs/generator/javac/TypesUtils.java
+++ b/generator/src/main/java/org/stjs/generator/javac/TypesUtils.java
@@ -15,7 +15,7 @@ import com.sun.tools.javac.model.JavacTypes;
 
 /**
  * A utility class that helps with {@link TypeMirror}s.
- * 
+ *
  */
 // TODO: This class needs significant restructuring
 @edu.umd.cs.findbugs.annotations.SuppressWarnings(
@@ -31,7 +31,7 @@ public final class TypesUtils {
 
 	/**
 	 * Gets the fully qualified name for a provided type. It returns an empty name if type is an anonymous type.
-	 * 
+	 *
 	 * @param type
 	 *            the declared type
 	 * @return the name corresponding to that type
@@ -43,7 +43,7 @@ public final class TypesUtils {
 
 	/**
 	 * Checks if the type represents a java.lang.Object declared type.
-	 * 
+	 *
 	 * @param type
 	 *            the type
 	 * @return true iff type represents java.lang.Object
@@ -54,7 +54,7 @@ public final class TypesUtils {
 
 	/**
 	 * Checks if the type represents a java.lang.Class declared type.
-	 * 
+	 *
 	 * @param type
 	 *            the type
 	 * @return true iff type represents java.lang.Class
@@ -67,7 +67,7 @@ public final class TypesUtils {
 	 * Checks if the type represents a java.lang.String declared type. TODO: it would be cleaner to use
 	 * String.class.getCanonicalName(), but the two existing methods above don't do that, I guess for performance
 	 * reasons.
-	 * 
+	 *
 	 * @param type
 	 *            the type
 	 * @return true iff type represents java.lang.String
@@ -78,7 +78,7 @@ public final class TypesUtils {
 
 	/**
 	 * Checks if the type represents a boolean type, that is either boolean (primitive type) or java.lang.Boolean.
-	 * 
+	 *
 	 * @param type
 	 *            the type to test
 	 * @return true iff type represents a boolean type
@@ -89,7 +89,7 @@ public final class TypesUtils {
 
 	/**
 	 * Check if the type represent a declared type of the given qualified name
-	 * 
+	 *
 	 * @param type
 	 *            the type
 	 * @return type iff type represents a declared type of the qualified name
@@ -130,7 +130,7 @@ public final class TypesUtils {
 
 	/**
 	 * Returns true iff the argument is a primitive type.
-	 * 
+	 *
 	 * @return whether the argument is a primitive type
 	 */
 	public static boolean isPrimitive(TypeMirror type) {
@@ -152,7 +152,7 @@ public final class TypesUtils {
 
 	/**
 	 * Returns true iff the arguments are both the same primitive types.
-	 * 
+	 *
 	 * @return whether the arguments are the same primitive types
 	 */
 	public static boolean areSamePrimitiveTypes(TypeMirror left, TypeMirror right) {
@@ -165,7 +165,7 @@ public final class TypesUtils {
 
 	/**
 	 * Returns true iff the argument is a primitive numeric type.
-	 * 
+	 *
 	 * @return whether the argument is a primitive numeric type
 	 */
 	public static boolean isNumeric(TypeMirror type) {
@@ -186,7 +186,7 @@ public final class TypesUtils {
 
 	/**
 	 * Returns true iff the argument is an integral type.
-	 * 
+	 *
 	 * @return whether the argument is an integral type
 	 */
 	public static boolean isIntegral(TypeMirror type) {
@@ -205,7 +205,7 @@ public final class TypesUtils {
 
 	/**
 	 * Returns true iff the argument is a floating point type.
-	 * 
+	 *
 	 * @return whether the argument is a floating point type
 	 */
 	public static boolean isFloating(TypeMirror type) {
@@ -223,7 +223,7 @@ public final class TypesUtils {
 	 * Returns the widened numeric type for an arithmetic operation performed on a value of the left type and the right
 	 * type. Defined in JLS 5.6.2. We return a {@link TypeKind} because creating a {@link TypeMirror} requires a
 	 * {@link Types} object from the {@link javax.annotation.processing.ProcessingEnvironment}.
-	 * 
+	 *
 	 * @return the result of widening numeric conversion, or NONE when the conversion cannot be performed
 	 */
 	public static TypeKind widenedNumericType(TypeMirror left, TypeMirror right) {
@@ -252,7 +252,7 @@ public final class TypesUtils {
 	/**
 	 * If the argument is a bounded TypeVariable or WildcardType, return its non-variable, non-wildcard upper bound.
 	 * Otherwise, return the type itself.
-	 * 
+	 *
 	 * @param type
 	 *            a type
 	 * @return the non-variable, non-wildcard upper bound of a type, if it has one, or itself if it has no bounds
@@ -310,5 +310,6 @@ public final class TypesUtils {
 		JavacTypes t = (JavacTypes) types;
 		return t.getArrayType(componentType);
 	}
+
 }
 // CHECKSTYLE:ON

--- a/generator/src/main/java/org/stjs/generator/name/DefaultJavaScriptNameProvider.java
+++ b/generator/src/main/java/org/stjs/generator/name/DefaultJavaScriptNameProvider.java
@@ -1,12 +1,7 @@
 package org.stjs.generator.name;
 
-import com.sun.source.tree.ExpressionTree;
-import com.sun.source.tree.IdentifierTree;
-import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
-import com.sun.source.util.TreePath;
-import com.sun.tools.javac.code.Symbol;
 import org.stjs.generator.AnnotationUtils;
 import org.stjs.generator.GenerationContext;
 import org.stjs.generator.GeneratorConfiguration;
@@ -21,10 +16,14 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
+import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.WildcardType;
+import javax.lang.model.util.ElementFilter;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -33,252 +32,335 @@ import java.util.Map;
  * @author acraciun
  */
 public class DefaultJavaScriptNameProvider implements JavaScriptNameProvider {
-	private static final String JAVA_LANG_PACKAGE = "java.lang.";
-	private static final int JAVA_LANG_LENGTH = JAVA_LANG_PACKAGE.length();
+    private static final String JAVA_LANG_PACKAGE = "java.lang.";
+    private static final int JAVA_LANG_LENGTH = JAVA_LANG_PACKAGE.length();
 
-	private final Map<String, DependencyType> resolvedRootTypes = new HashMap<String, DependencyType>();
-	private final Map<TypeMirror, TypeInfo> resolvedTypes = new HashMap<TypeMirror, TypeInfo>();
+    private final Map<String, DependencyType> resolvedRootTypes = new HashMap<String, DependencyType>();
+    private final Map<TypeMirror, TypeInfo> resolvedTypes = new HashMap<TypeMirror, TypeInfo>();
 
-	private class TypeInfo {
-		private final String fullName;
-		private final Element rootTypeElement;
+    private class TypeInfo {
+        private final String fullName;
+        private final Element rootTypeElement;
 
-		public TypeInfo(String fullName, Element rootTypeElement) {
-			this.fullName = fullName;
-			this.rootTypeElement = rootTypeElement;
-		}
+        public TypeInfo(String fullName, Element rootTypeElement) {
+            this.fullName = fullName;
+            this.rootTypeElement = rootTypeElement;
+        }
 
-		public String getFullName() {
-			return fullName;
-		}
+        public String getFullName() {
+            return fullName;
+        }
 
-		public Element getRootTypeElement() {
-			return rootTypeElement;
-		}
+        public Element getRootTypeElement() {
+            return rootTypeElement;
+        }
 
-	}
+    }
 
-	private String addNameSpace(Element rootTypeElement, GenerationContext<?> context, String name) {
-		String namespace = context.wrap(rootTypeElement).getNamespace();
-		if (namespace.isEmpty()) {
-			return name;
-		}
-		return namespace + "." + name;
-	}
+    private String addNameSpace(Element rootTypeElement, GenerationContext<?> context, String name) {
+        String namespace = context.wrap(rootTypeElement).getNamespace();
+        if (namespace.isEmpty()) {
+            return name;
+        }
+        return namespace + "." + name;
+    }
 
-	@Override
-	public String getTypeName(GenerationContext<?> context, TypeMirror type, DependencyType dependencyType) {
-		TypeInfo typeInfo = resolvedTypes.get(type);
-		if (typeInfo != null) {
-			// make sure we have the strictest dep type
-			addResolvedType(typeInfo.getRootTypeElement(), dependencyType);
-			return typeInfo.getFullName();
-		}
+    @Override
+    public String getTypeName(GenerationContext<?> context, TypeMirror type, DependencyType dependencyType) {
+        TypeInfo typeInfo = resolvedTypes.get(type);
+        if (typeInfo != null) {
+            // make sure we have the strictest dep type
+            addResolvedType(typeInfo.getRootTypeElement(), dependencyType);
+            return typeInfo.getFullName();
+        }
 
-		if (type instanceof DeclaredType) {
-			DeclaredType declaredType = (DeclaredType) type;
-			String name = InternalUtils.getSimpleName(declaredType.asElement());
-			Element rootTypeElement = declaredType.asElement();
-			for (DeclaredType enclosingType = JavaNodes.getEnclosingType(declaredType); enclosingType != null; enclosingType = JavaNodes
-					.getEnclosingType(enclosingType)) {
-				rootTypeElement = enclosingType.asElement();
-				name = InternalUtils.getSimpleName(rootTypeElement) + "." + name;
-			}
+        if (type instanceof DeclaredType) {
+            DeclaredType declaredType = (DeclaredType) type;
+            String name = InternalUtils.getSimpleName(declaredType.asElement());
+            Element rootTypeElement = declaredType.asElement();
+            for (DeclaredType enclosingType = JavaNodes.getEnclosingType(declaredType); enclosingType != null; enclosingType = JavaNodes
+                    .getEnclosingType(enclosingType)) {
+                rootTypeElement = enclosingType.asElement();
+                name = InternalUtils.getSimpleName(rootTypeElement) + "." + name;
+            }
 
-			checkAllowedType(rootTypeElement, context);
-			addResolvedType(rootTypeElement, dependencyType);
+            checkAllowedType(rootTypeElement, context);
+            addResolvedType(rootTypeElement, dependencyType);
 
-			String fullName = addNameSpace(rootTypeElement, context, name);
-			resolvedTypes.put(type, new TypeInfo(fullName, rootTypeElement));
-			return fullName;
-		}
-		if (type instanceof WildcardType) {
-			// ? extends Type1 super Type2
-			// XXX what to return here !?
-			return "Object";
-		}
-		return type.toString();
-	}
+            String fullName = addNameSpace(rootTypeElement, context, name);
+            resolvedTypes.put(type, new TypeInfo(fullName, rootTypeElement));
+            return fullName;
+        }
+        if (type instanceof WildcardType) {
+            // ? extends Type1 super Type2
+            // XXX what to return here !?
+            return "Object";
+        }
+        return type.toString();
+    }
 
-	private void typeNotAllowedException(GenerationContext<?> context, String name) {
-		context.addError(context.getCurrentPath().getLeaf(), "The usage of the class " + name
-				+ " is not allowed. If it's one of your own bridge types, "
-				+ "please add the annotation @STJSBridge to the class or to its package.");
-	}
+    private void typeNotAllowedException(GenerationContext<?> context, String name) {
+        context.addError(context.getCurrentPath().getLeaf(), "The usage of the class " + name
+                + " is not allowed. If it's one of your own bridge types, "
+                + "please add the annotation @STJSBridge to the class or to its package.");
+    }
 
-	private boolean isJavaLangClassAllowed(GenerationContext<?> context, String name) {
-		GeneratorConfiguration configuration = context.getConfiguration();
-		if (name.startsWith(JAVA_LANG_PACKAGE) && configuration.getAllowedJavaLangClasses().contains(name.substring(JAVA_LANG_LENGTH))) {
-			return true;
-		}
+    private boolean isJavaLangClassAllowed(GenerationContext<?> context, String name) {
+        GeneratorConfiguration configuration = context.getConfiguration();
+        if (name.startsWith(JAVA_LANG_PACKAGE) && configuration.getAllowedJavaLangClasses().contains(name.substring(JAVA_LANG_LENGTH))) {
+            return true;
+        }
 
-		return false;
-	}
+        return false;
+    }
 
-	private boolean isPackageAllowed(GenerationContext<?> context, String name) {
-		if (name.startsWith(JAVA_LANG_PACKAGE)) {
-			return false;
-		}
-		GeneratorConfiguration configuration = context.getConfiguration();
-		for (String packageName : configuration.getAllowedPackages()) {
-			if (name.startsWith(packageName)) {
-				return true;
-			}
-		}
-		return false;
-	}
+    private boolean isPackageAllowed(GenerationContext<?> context, String name) {
+        if (name.startsWith(JAVA_LANG_PACKAGE)) {
+            return false;
+        }
+        GeneratorConfiguration configuration = context.getConfiguration();
+        for (String packageName : configuration.getAllowedPackages()) {
+            if (name.startsWith(packageName)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
-	private boolean isBridge(GenerationContext<?> context, String name) {
-		if (name.startsWith(JAVA_LANG_PACKAGE)) {
-			return false;
-		}
+    private boolean isBridge(GenerationContext<?> context, String name) {
+        if (name.startsWith(JAVA_LANG_PACKAGE)) {
+            return false;
+        }
 
-		return ClassUtils.isBridge(context.getBuiltProjectClassLoader(), ClassUtils.getClazz(context.getBuiltProjectClassLoader(), name));
-	}
+        return ClassUtils.isBridge(context.getBuiltProjectClassLoader(), ClassUtils.getClazz(context.getBuiltProjectClassLoader(), name));
+    }
 
-	private void checkAllowedType(Element rootTypeElement, GenerationContext<?> context) {
-		String name = ElementUtils.getQualifiedClassName(rootTypeElement).toString();
-		if (name.isEmpty()) {
-			return;
-		}
-		if (isJavaLangClassAllowed(context, name)) {
-			return;
-		}
+    private void checkAllowedType(Element rootTypeElement, GenerationContext<?> context) {
+        String name = ElementUtils.getQualifiedClassName(rootTypeElement).toString();
+        if (name.isEmpty()) {
+            return;
+        }
+        if (isJavaLangClassAllowed(context, name)) {
+            return;
+        }
 
-		if (isImportedStjsClass(context, name)) {
-			return;
-		}
+        if (isImportedStjsClass(context, name)) {
+            return;
+        }
 
-		if (isPackageAllowed(context, name)) {
-			return;
-		}
+        if (isPackageAllowed(context, name)) {
+            return;
+        }
 
-		// ClassUtils.isBridge accepts all java.lang classes, that are actually not allowed
-		if (isBridge(context, name)) {
-			return;
-		}
+        // ClassUtils.isBridge accepts all java.lang classes, that are actually not allowed
+        if (isBridge(context, name)) {
+            return;
+        }
 
-		typeNotAllowedException(context, name);
-	}
+        typeNotAllowedException(context, name);
+    }
 
-	private boolean isImportedStjsClass(GenerationContext<?> context, String className) {
-		String stjsPropertiesName = ClassUtils.getPropertiesFileName(className);
-		return context.getBuiltProjectClassLoader().getResource(stjsPropertiesName) != null;
-	}
+    private boolean isImportedStjsClass(GenerationContext<?> context, String className) {
+        String stjsPropertiesName = ClassUtils.getPropertiesFileName(className);
+        return context.getBuiltProjectClassLoader().getResource(stjsPropertiesName) != null;
+    }
 
-	private void addResolvedType(Element rootTypeElement, DependencyType depType) {
-		String name = ElementUtils.getQualifiedClassName(rootTypeElement).toString();
-		if (!name.startsWith("java.lang.")) {
-			DependencyType prevDepType = resolvedRootTypes.get(name);
-			if (prevDepType == null || depType.isStricter(prevDepType)) {
-				resolvedRootTypes.put(name, depType);
-			}
-		}
-	}
+    private void addResolvedType(Element rootTypeElement, DependencyType depType) {
+        String name = ElementUtils.getQualifiedClassName(rootTypeElement).toString();
+        if (!name.startsWith("java.lang.")) {
+            DependencyType prevDepType = resolvedRootTypes.get(name);
+            if (prevDepType == null || depType.isStricter(prevDepType)) {
+                resolvedRootTypes.put(name, depType);
+            }
+        }
+    }
 
-	public String getFieldName(GenerationContext<?> context, MethodInvocationTree tree) {
-		String name = context.getNames().getMethodName(context, tree);
-		int start = name.startsWith("$") ? 1 : 0;
-		return name.substring(start);
-	}
+    @Override
+    public String transformMethodCallToFieldName(GenerationContext<?> context, MethodInvocationTree tree) {
+        String methodName = getMethodName(context, tree);
 
-	@Override
-	public String getMethodName(GenerationContext<?> context, MethodTree tree) {
-		Symbol.MethodSymbol element = (Symbol.MethodSymbol) context.getCurrentWrapper().getElement();
-		String methodName = element.getSimpleName().toString();
+        if (methodName.startsWith(GeneratorConstants.AUTO_GENERATED_ELEMENT_SEPARATOR)) {
+            methodName = methodName.substring(1, methodName.length());
+        }
 
-		if (AnnotationUtils.JSOverloadName.isPresent(element)
-				|| ElementUtils.hasAnOverloadedEquivalentMethod(TreeUtils.elementFromDeclaration(tree), context.getElements())) {
-			methodName = AnnotationUtils.JSOverloadName.decorate(element);
-		}
+        int idx = methodName.indexOf(GeneratorConstants.AUTO_GENERATED_ELEMENT_SEPARATOR);
+        if (idx > 0) {
+            methodName = methodName.substring(0, idx);
+        }
 
-		if (!JavaNodes.isPublic(tree) && !isFromInterface(context)) {
-			return GeneratorConstants.NON_PUBLIC_METHODS_AND_FIELDS_PREFIX + methodName;
-		}
+        return methodName;
+    }
 
-		return methodName;
-	}
+    @Override
+    public String getMethodName(GenerationContext<?> context, MethodTree methodTree) {
+        return getMethodName(context,
+                TreeUtils.elementFromDeclaration(methodTree));
+    }
 
+    @Override
+    public String getMethodName(GenerationContext<?> context, MethodInvocationTree tree) {
+        ExecutableElement executableElement = TreeUtils.elementFromUse(tree);
 
-	private boolean isFromInterface(GenerationContext<?> context) {
-		return ElementKind.INTERFACE.equals(context.getCurrentWrapper().getEnclosingType().getElement().getKind());
-	}
+        // Ignore super() calls, these are never going to be prefixed
+        if (ElementUtils.isConstructor(executableElement)) {
+            return GeneratorConstants.SUPER;
+        }
 
-	@Override
-	public String getMethodName(GenerationContext<?> context, MethodInvocationTree tree) {
-		ExpressionTree select = tree.getMethodSelect();
+        return getMethodName(context, executableElement);
+    }
 
-		if (select instanceof IdentifierTree) {
-			// simple call: method(args)
-			return buildMethodNameForIdentifierTree(tree, context, (IdentifierTree) select);
-		} else if (select instanceof MemberSelectTree) {
-			// calls with target: target.method(args)
-			return buildMethodNameForMemberSelectTree(context, (MemberSelectTree) select);
-		}
-		throw context.addError(tree, "Unsupported tree type during buildMethodName.");
-	}
+    @Override
+    public String getMethodName(GenerationContext<?> context, ExecutableElement methodElement) {
 
-	@Override
-	public String getTypeName(GenerationContext<?> context, Element type, DependencyType dependencyType) {
-		if (type == null) {
-			return null;
-		}
-		return getTypeName(context, type.asType(), dependencyType);
-	}
+        String annotationValue = AnnotationUtils.JSOverloadName.getAnnotationValue(context, methodElement);
+        if (annotationValue != null) {
+            return decorateNonPublicMembers(methodElement, annotationValue);
+        }
 
-	@Override
-	public Map<String, DependencyType> getResolvedTypes() {
-		return resolvedRootTypes;
-	}
+        List<ExecutableElement> sameMethodsFromParents =
+                ElementUtils.getSameMethodsFromSupertypes(ElementUtils.enclosingClass(methodElement), methodElement);
 
-	private <JS> String buildMethodNameForIdentifierTree(MethodInvocationTree tree, GenerationContext<JS> context, IdentifierTree select) {
-		String methodName = select.getName().toString();
+        if (sameMethodsFromParents.isEmpty()) {
+            return getMethodNameFromClass(context, methodElement);
+        } else {
+            // found same method in some of parent class.
+            // Ensure all parent classes returns the same name for the method
+            Map<String, List<ExecutableElement>> allMethodNamesFromSuperTypes = new HashMap<>();
+            for (ExecutableElement sameMethodFromParent : sameMethodsFromParents) {
+                String methodName = getMethodName(context, sameMethodFromParent);
 
-		// Ignore super() calls, these are never going to be prefixed
-		if (GeneratorConstants.SUPER.equals(methodName)) {
-			return methodName;
-		}
+                List<ExecutableElement> matchingExecutableElements = allMethodNamesFromSuperTypes.get(methodName);
+                if (matchingExecutableElements == null) {
+                    matchingExecutableElements = new ArrayList<>();
+                    allMethodNamesFromSuperTypes.put(methodName, matchingExecutableElements);
+                }
+                matchingExecutableElements.add(sameMethodFromParent);
+            }
 
-		Symbol symbol = (Symbol.MethodSymbol) InternalUtils.symbol(tree);
-		ExecutableElement methodElement = TreeUtils.getMethod(symbol);
+            if (allMethodNamesFromSuperTypes.size() >= 2) {
+                context.addError(context.getCurrentPath().getCompilationUnit(),
+                        String.format(
+                                "" +
+                                        "Method name conflict for method with signature: [%s.%s]. " +
+                                        "Parent class hierarchy uses different method names fro the same method type erasure: %s",
+                                methodElement.getEnclosingElement().getSimpleName(),
+                                methodElement.toString(),
+                                buildOverridenMethodErrorMessage(allMethodNamesFromSuperTypes)));
+            }
 
-		if (methodElement != null
-				&& (AnnotationUtils.JSOverloadName.isPresent(methodElement)
-				|| hasAnOverloadedMethod(context, methodElement))) {
-			methodName = AnnotationUtils.JSOverloadName.decorate((Symbol.MethodSymbol) methodElement);
-		}
-		return prefixNonPublicMethods(methodName, symbol);
-	}
+            // return first
+            return allMethodNamesFromSuperTypes.keySet().iterator().next();
+        }
+    }
 
-	private <JS> String buildMethodNameForMemberSelectTree(GenerationContext<JS> context, MemberSelectTree memberSelect) {
-		String methodName = memberSelect.getIdentifier().toString();
-		Symbol symbol = (Symbol) InternalUtils.symbol(memberSelect);
+    private String buildOverridenMethodErrorMessage(Map<String, List<ExecutableElement>> allMethodNamesFromSuperTypes) {
+        StringBuilder sb = new StringBuilder();
 
-		if (symbol != null && TreeUtils.isFieldAccess(memberSelect.getExpression())
-				&& (symbol.getKind() == ElementKind.FIELD || symbol.getKind() == ElementKind.METHOD)) {
-			return prefixNonPublicMethods(methodName, symbol);
-		}
+        for (Map.Entry<String, List<ExecutableElement>> mapEntry : allMethodNamesFromSuperTypes.entrySet()) {
+            if (sb.length() > 0) {
+                sb.append(", ");
+            }
+            sb.append("'");
+            sb.append(mapEntry.getKey());
+            sb.append("' --> ");
 
-		ExecutableElement methodElement = TreeUtils.getMethod(symbol);
-		if (hasAnOverloadedMethod(context, methodElement)) {
-			return AnnotationUtils.JSOverloadName.decorate((Symbol.MethodSymbol) methodElement);
-		}
-		return methodName;
-	}
+            List<ExecutableElement> value = mapEntry.getValue();
 
-	private <JS> boolean hasAnOverloadedMethod(GenerationContext<JS> context, ExecutableElement methodElement) {
-		if (context == null) {
-			return false;
-		}
-		return ElementUtils.hasAnOverloadedEquivalentMethod(methodElement, context.getElements());
-	}
+            sb.append("[");
+            int sbLengthBeforeLoop = sb.length();
+            for (ExecutableElement executableElement : value) {
+                if (sb.length() != sbLengthBeforeLoop) {
+                    sb.append(", ");
+                }
 
-	private String prefixNonPublicMethods(String methodName, Symbol element) {
-		if (element != null && element.getModifiers().contains(Modifier.PUBLIC)) {
-			return methodName;
-		} else {
-			return GeneratorConstants.NON_PUBLIC_METHODS_AND_FIELDS_PREFIX + methodName;
-		}
-	}
+                sb.append(executableElement.getEnclosingElement().getSimpleName());
+                sb.append(".");
+                sb.append(executableElement.toString());
+            }
+            sb.append("]");
+
+            sb.append(mapEntry.getValue().toString());
+        }
+
+        return sb.toString();
+    }
+
+    private String getMethodNameFromClass(GenerationContext context, ExecutableElement methodElement) {
+        String methodName = methodElement.getSimpleName().toString();
+
+        List<ExecutableElement> methodsInClassWithSameName = findAllMethodsInClassWithSameName(methodElement);
+        if (methodsInClassWithSameName.isEmpty() && !ElementUtils.isConstructor(methodElement)) {
+            throw new AssertionError("Should have matched at least the current method.");
+        }
+        methodsInClassWithSameName = filterOutNativeMethods(methodsInClassWithSameName);
+
+        boolean isAnOverloadedMethod = (methodsInClassWithSameName.size() >= 2);
+
+        if (isAnOverloadedMethod) {
+            // generate method name with argument types
+            List<? extends VariableElement> params = methodElement.getParameters();
+            methodName = InternalUtils.generateOverloadedMethodName(context, methodName, params);
+        }
+
+        methodName = decorateNonPublicMembers(methodElement, methodName);
+
+        return methodName;
+    }
+
+    private List<ExecutableElement> filterOutNativeMethods(List<ExecutableElement> methodsInClassWithSameName) {
+        List<ExecutableElement> filteredList = new ArrayList<>();
+
+        for (ExecutableElement executableElement : methodsInClassWithSameName) {
+            if (!executableElement.getModifiers().contains(Modifier.NATIVE)) {
+                filteredList.add(executableElement);
+            }
+        }
+
+        return filteredList;
+    }
+
+    private String decorateNonPublicMembers(Element element, String memberName) {
+        String decoratedMemberName = memberName;
+
+        boolean isPublic = element.getModifiers().contains(Modifier.PUBLIC)
+                || element.getEnclosingElement().getKind() == ElementKind.INTERFACE;
+
+        if (!isPublic) {
+            decoratedMemberName = GeneratorConstants.NON_PUBLIC_METHODS_AND_FIELDS_PREFIX + memberName;
+        }
+
+        return decoratedMemberName;
+    }
+
+    private List<ExecutableElement> findAllMethodsInClassWithSameName(ExecutableElement methodElement) {
+        String methodSimpleName = methodElement.getSimpleName().toString();
+
+        List<ExecutableElement> methodsInClassWithSameName = new ArrayList<>();
+        List<ExecutableElement> allMethodsInClass = ElementFilter.methodsIn(methodElement.getEnclosingElement().getEnclosedElements());
+        for (ExecutableElement method : allMethodsInClass) {
+            if (method.getSimpleName().toString().equals(methodSimpleName)) {
+                methodsInClassWithSameName.add(method);
+            }
+        }
+
+        return methodsInClassWithSameName;
+    }
+
+    private boolean isFromInterface(GenerationContext<?> context) {
+        return ElementKind.INTERFACE.equals(context.getCurrentWrapper().getEnclosingType().getElement().getKind());
+    }
+
+    @Override
+    public String getTypeName(GenerationContext<?> context, Element type, DependencyType dependencyType) {
+        if (type == null) {
+            return null;
+        }
+        return getTypeName(context, type.asType(), dependencyType);
+    }
+
+    @Override
+    public Map<String, DependencyType> getResolvedTypes() {
+        return resolvedRootTypes;
+    }
 
 }

--- a/generator/src/main/java/org/stjs/generator/name/JavaScriptNameProvider.java
+++ b/generator/src/main/java/org/stjs/generator/name/JavaScriptNameProvider.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import javax.lang.model.element.Element;
 import javax.lang.model.type.TypeMirror;
 
+import com.sun.source.tree.MemberSelectTree;
 import org.stjs.generator.GenerationContext;
 
 import com.sun.source.tree.IdentifierTree;
@@ -17,11 +18,11 @@ public interface JavaScriptNameProvider {
 
 	String getTypeName(GenerationContext<?> context, Element type, DependencyType dependencyType);
 
-	String getVariableName(GenerationContext<?> context, IdentifierTree treeNode, TreePath path);
+	String getFieldName(GenerationContext<?> context, MethodInvocationTree tree);
 
-	String getMethodName(GenerationContext<?> context, MethodTree tree, TreePath path);
+	String getMethodName(GenerationContext<?> context, MethodTree tree);
 
-	String getMethodName(GenerationContext<?> context, MethodInvocationTree tree, TreePath path);
+	String getMethodName(GenerationContext<?> context, MethodInvocationTree tree);
 
 	Map<String, DependencyType> getResolvedTypes();
 }

--- a/generator/src/main/java/org/stjs/generator/name/JavaScriptNameProvider.java
+++ b/generator/src/main/java/org/stjs/generator/name/JavaScriptNameProvider.java
@@ -3,6 +3,7 @@ package org.stjs.generator.name;
 import java.util.Map;
 
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.type.TypeMirror;
 
 import com.sun.source.tree.MemberSelectTree;
@@ -18,11 +19,14 @@ public interface JavaScriptNameProvider {
 
 	String getTypeName(GenerationContext<?> context, Element type, DependencyType dependencyType);
 
-	String getFieldName(GenerationContext<?> context, MethodInvocationTree tree);
-
 	String getMethodName(GenerationContext<?> context, MethodTree tree);
 
 	String getMethodName(GenerationContext<?> context, MethodInvocationTree tree);
 
+	String getMethodName(GenerationContext<?> context, ExecutableElement method);
+
+	String transformMethodCallToFieldName(GenerationContext<?> context, MethodInvocationTree tree);
+
 	Map<String, DependencyType> getResolvedTypes();
+
 }

--- a/generator/src/main/java/org/stjs/generator/writer/declaration/ClassWriter.java
+++ b/generator/src/main/java/org/stjs/generator/writer/declaration/ClassWriter.java
@@ -213,7 +213,7 @@ public class ClassWriter<JS> extends AbstractMemberWriter<JS> implements WriterC
 		for (MethodTree constructor : constructors) {
 			Element element = InternalUtils.symbol(constructor);
 			if (element instanceof Symbol.MethodSymbol) {
-				constructorName = InternalUtils.generateOverloadeConstructorName(((Symbol.MethodSymbol) element).params());
+				constructorName = InternalUtils.generateOverloadeConstructorName(context, ((Symbol.MethodSymbol) element).params());
 			}
 			JS block = visitor.scan(constructor.getBody(), context);
 			List<JS> params = MethodWriter.getParams(constructor.getParameters(), context);

--- a/generator/src/main/java/org/stjs/generator/writer/declaration/MethodWriter.java
+++ b/generator/src/main/java/org/stjs/generator/writer/declaration/MethodWriter.java
@@ -69,19 +69,7 @@ public class MethodWriter<JS> extends AbstractMemberWriter<JS> implements Writer
 	}
 
 	private String decorateMethodName(MethodTree tree, GenerationContext<JS> context) {
-		Symbol.MethodSymbol element = (Symbol.MethodSymbol) context.getCurrentWrapper().getElement();
-		String methodName = element.getSimpleName().toString();
-
-		if (AnnotationUtils.JSOverloadName.isPresent(element)
-				|| ElementUtils.hasAnOverloadedEquivalentMethod(TreeUtils.elementFromDeclaration(tree), context.getElements())) {
-			methodName = AnnotationUtils.JSOverloadName.decorate(element);
-		}
-
-		if (!JavaNodes.isPublic(tree) && !isFromInterface(context)) {
-			return GeneratorConstants.NON_PUBLIC_METHODS_AND_FIELDS_PREFIX + methodName;
-		}
-
-		return methodName;
+		return context.getNames().getMethodName(context, tree);
 	}
 
 	private boolean isFromInterface(GenerationContext<JS> context) {

--- a/generator/src/main/java/org/stjs/generator/writer/expression/NewClassWriter.java
+++ b/generator/src/main/java/org/stjs/generator/writer/expression/NewClassWriter.java
@@ -25,7 +25,6 @@ import org.stjs.generator.name.DependencyType;
 import org.stjs.generator.writer.WriterContributor;
 import org.stjs.generator.writer.WriterVisitor;
 import org.stjs.generator.writer.declaration.MethodWriter;
-import org.stjs.generator.writer.templates.MethodToPropertyTemplate;
 import org.stjs.javascript.annotation.Namespace;
 
 import javax.lang.model.element.Element;
@@ -85,7 +84,7 @@ public class NewClassWriter<JS> implements WriterContributor<NewClassTree, JS> {
 
 				} else {
 					MethodInvocationTree meth = (MethodInvocationTree) expr;
-					String propertyName = tw.getContext().getNames().getFieldName(tw.getContext(), meth);
+					String propertyName = tw.getContext().getNames().transformMethodCallToFieldName(tw.getContext(), meth);
 					JS value = visitor.scan(meth.getArguments().get(0), tw.getContext());
 					props.add(NameValue.of(propertyName, value));
 				}
@@ -202,7 +201,7 @@ public class NewClassWriter<JS> implements WriterContributor<NewClassTree, JS> {
 		if (identifierHasMultipleConstructors(tree.getIdentifier())) {
 			List<JS> params = arguments(visitor, tree, context);
 			ExecutableElement element = TreeUtils.elementFromUse(tree);
-			String constructorName = InternalUtils.generateOverloadeConstructorName(((Symbol.MethodSymbol) element).getParameters());
+			String constructorName = InternalUtils.generateOverloadeConstructorName(context, ((Symbol.MethodSymbol) element).getParameters());
 			js = context.js().functionCall(context.js().property(js, constructorName), params);
 		}
 

--- a/generator/src/main/java/org/stjs/generator/writer/expression/NewClassWriter.java
+++ b/generator/src/main/java/org/stjs/generator/writer/expression/NewClassWriter.java
@@ -85,7 +85,7 @@ public class NewClassWriter<JS> implements WriterContributor<NewClassTree, JS> {
 
 				} else {
 					MethodInvocationTree meth = (MethodInvocationTree) expr;
-					String propertyName = MethodToPropertyTemplate.getPropertyName(meth);
+					String propertyName = tw.getContext().getNames().getFieldName(tw.getContext(), meth);
 					JS value = visitor.scan(meth.getArguments().get(0), tw.getContext());
 					props.add(NameValue.of(propertyName, value));
 				}

--- a/generator/src/main/java/org/stjs/generator/writer/templates/AdapterTemplate.java
+++ b/generator/src/main/java/org/stjs/generator/writer/templates/AdapterTemplate.java
@@ -22,7 +22,7 @@ public class AdapterTemplate<JS> implements WriterContributor<MethodInvocationTr
 		if (argCount < 1) {
 			throw context.addError(tree, "An 'adapter' template can only be applied for methods with at least 1 parameter");
 		}
-		String name = MethodInvocationWriter.buildMethodName(tree, context);
+		String name = context.getNames().getMethodName(context, tree);
 		List<JS> arguments = MethodInvocationWriter.buildArguments(visitor, tree, context);
 
 		JS target = context.js().paren(arguments.get(0));

--- a/generator/src/main/java/org/stjs/generator/writer/templates/AssertTemplate.java
+++ b/generator/src/main/java/org/stjs/generator/writer/templates/AssertTemplate.java
@@ -24,7 +24,7 @@ public class AssertTemplate<JS> implements WriterContributor<MethodInvocationTre
 		if (argCount < 1) {
 			throw context.addError(tree, "An 'adapter' template can only be applied for methods with at least 1 parameter");
 		}
-		String name = MethodInvocationWriter.buildMethodName(tree, context);
+		String name = context.getNames().getMethodName(context, tree);
 		JS target = MethodInvocationWriter.buildTarget(visitor, context.<MethodInvocationTree>getCurrentWrapper());
 		List<JS> arguments = MethodInvocationWriter.buildArguments(visitor, tree, context);
 		arguments.add(0, context.js().string(context.getInputFile().getName() + ":" + context.getStartLine(tree)));

--- a/generator/src/main/java/org/stjs/generator/writer/templates/DefaultTemplate.java
+++ b/generator/src/main/java/org/stjs/generator/writer/templates/DefaultTemplate.java
@@ -99,7 +99,7 @@ public class DefaultTemplate<JS> implements WriterContributor<MethodInvocationTr
 		ExecutableElement element = TreeUtils.elementFromUse(tree);
 		if (JavaNodes.hasMultipleConstructors(context.getCurrentPath()) && ElementKind.CONSTRUCTOR.equals(element.getKind())) {
 			// Invocation of a another constructor, let's get the overloaded constructor name and chain the real static constructor
-			String constructorName = InternalUtils.generateOverloadeConstructorName(((Symbol.MethodSymbol) element).getParameters());
+			String constructorName = InternalUtils.generateOverloadeConstructorName(context, ((Symbol.MethodSymbol) element).getParameters());
 			return context.js().functionCall(context.js().property(target, constructorName), arguments);
 		}
 		return null;

--- a/generator/src/main/java/org/stjs/generator/writer/templates/DefaultTemplate.java
+++ b/generator/src/main/java/org/stjs/generator/writer/templates/DefaultTemplate.java
@@ -47,7 +47,7 @@ public class DefaultTemplate<JS> implements WriterContributor<MethodInvocationTr
 		Element methodElement = TreeUtils.elementFromUse(tree);
 		TypeElement typeElement = (TypeElement) methodElement.getEnclosingElement();
 
-		String methodName = MethodInvocationWriter.buildMethodName(tree, context);
+		String methodName = context.getNames().getMethodName(context, tree);
 
 		// avoid useless call to super() when the super class is Object
 		if (GeneratorConstants.SUPER.equals(methodName) && JavaNodes.sameRawType(typeElement.asType(), Object.class)) {
@@ -90,7 +90,7 @@ public class DefaultTemplate<JS> implements WriterContributor<MethodInvocationTr
 			return constructorName;
 		}
 
-		String name = MethodInvocationWriter.buildMethodName(tree, context);
+		String name = context.getNames().getMethodName(context, tree);
 		return context.js().functionCall(context.js().property(target, name), arguments);
 	}
 

--- a/generator/src/main/java/org/stjs/generator/writer/templates/MethodToPropertyTemplate.java
+++ b/generator/src/main/java/org/stjs/generator/writer/templates/MethodToPropertyTemplate.java
@@ -2,6 +2,7 @@ package org.stjs.generator.writer.templates;
 
 import com.sun.source.tree.MethodInvocationTree;
 import org.stjs.generator.GenerationContext;
+import org.stjs.generator.GeneratorConstants;
 import org.stjs.generator.javac.TreeUtils;
 import org.stjs.generator.javascript.AssignOperator;
 import org.stjs.generator.utils.JavaNodes;
@@ -41,7 +42,7 @@ public class MethodToPropertyTemplate<JS> implements WriterContributor<MethodInv
 		}
 
 		// NAME
-		JS property = context.js().property(target, context.getNames().getFieldName(context, tree));
+		JS property = context.js().property(target, context.getNames().transformMethodCallToFieldName(context, tree));
 
 		// VALUE
 		if (argCount == arg) {

--- a/generator/src/main/java/org/stjs/generator/writer/templates/MethodToPropertyTemplate.java
+++ b/generator/src/main/java/org/stjs/generator/writer/templates/MethodToPropertyTemplate.java
@@ -41,7 +41,7 @@ public class MethodToPropertyTemplate<JS> implements WriterContributor<MethodInv
 		}
 
 		// NAME
-		JS property = context.js().property(target, getPropertyName(tree));
+		JS property = context.js().property(target, context.getNames().getFieldName(context, tree));
 
 		// VALUE
 		if (argCount == arg) {
@@ -53,9 +53,4 @@ public class MethodToPropertyTemplate<JS> implements WriterContributor<MethodInv
 		return context.js().assignment(AssignOperator.ASSIGN, property, visitor.scan(tree.getArguments().get(arg), context));
 	}
 
-	public static String getPropertyName(MethodInvocationTree tree) {
-		String name = MethodInvocationWriter.buildMethodName(tree, null);
-		int start = name.startsWith("$") ? 1 : 0;
-		return name.substring(start);
-	}
 }

--- a/generator/src/main/java/org/stjs/generator/writer/templates/PrefixTemplate.java
+++ b/generator/src/main/java/org/stjs/generator/writer/templates/PrefixTemplate.java
@@ -26,7 +26,7 @@ public class PrefixTemplate<JS> implements WriterContributor<MethodInvocationTre
 	@Override
 	public JS visit(WriterVisitor<JS> visitor, MethodInvocationTree tree, GenerationContext<JS> context) {
 		JS target = MethodInvocationWriter.buildTarget(visitor, context.<MethodInvocationTree>getCurrentWrapper());
-		String name = MethodInvocationWriter.buildMethodName(tree, context);
+		String name = context.getNames().getMethodName(context, tree);
 		name = transformMethodName(name, context.getCurrentWrapper().getMethodTemplateParameters());
 		List<JS> arguments = MethodInvocationWriter.buildArguments(visitor, tree, context);
 		return context.js().functionCall(context.js().property(target, name), arguments);

--- a/generator/src/main/java/org/stjs/generator/writer/templates/SuffixTemplate.java
+++ b/generator/src/main/java/org/stjs/generator/writer/templates/SuffixTemplate.java
@@ -25,7 +25,7 @@ public class SuffixTemplate<JS> implements WriterContributor<MethodInvocationTre
 	@Override
 	public JS visit(WriterVisitor<JS> visitor, MethodInvocationTree tree, GenerationContext<JS> context) {
 		JS target = MethodInvocationWriter.buildTarget(visitor, context.<MethodInvocationTree>getCurrentWrapper());
-		String name = MethodInvocationWriter.buildMethodName(tree, context);
+		String name = context.getNames().getMethodName(context, tree);
 		name = transformMethodName(name, context.getCurrentWrapper().getMethodTemplateParameters());
 		List<JS> arguments = MethodInvocationWriter.buildArguments(visitor, tree, context);
 		return context.js().functionCall(context.js().property(target, name), arguments);

--- a/generator/src/test/java/org/stjs/generator/writer/fields/FieldsGeneratorTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/fields/FieldsGeneratorTest.java
@@ -272,10 +272,10 @@ public class FieldsGeneratorTest extends AbstractStjsTest {
 	public void testCreatedFixedArraySize() {
 		assertCodeContains(Fields31_create_fixed_array_size.class, "" +
 				"    this._aStringArray = stjs.createJavaArray(10);\n" +
-				"    this._aStringArray = stjs.createJavaArray(this.constructor.getSize2());\n" +
+				"    this._aStringArray = stjs.createJavaArray(this.constructor._getSize2());\n" +
 				"    this._aDoubleStringArray = stjs.createJavaArray(200, 300);\n" +
-				"    this._aDoubleStringArray = stjs.createJavaArray(this.constructor.getSize2(), 300);\n" +
-				"    this._aDoubleStringArray = stjs.createJavaArray(this.constructor.getSize2(), this.constructor.getSize3());\n");
+				"    this._aDoubleStringArray = stjs.createJavaArray(this.constructor._getSize2(), 300);\n" +
+				"    this._aDoubleStringArray = stjs.createJavaArray(this.constructor._getSize2(), this.constructor._getSize3());\n");
 	}
 
 	@Test

--- a/generator/src/test/java/org/stjs/generator/writer/methods/Methods27_overrride_and_overload_in_subclass_no_conflict.java
+++ b/generator/src/test/java/org/stjs/generator/writer/methods/Methods27_overrride_and_overload_in_subclass_no_conflict.java
@@ -1,0 +1,40 @@
+package org.stjs.generator.writer.methods;
+
+public class Methods27_overrride_and_overload_in_subclass_no_conflict<E> {
+
+    public static Object main(String[] args) {
+        SubClassClass subClassClass = new SubClassClass();
+        BaseClass subClassClassAsBaseClass = new SubClassClass();
+        BaseClass baseClass = new SubClassClass();
+        Interface1 subClassAsInterface = new SubClassClass();
+        BaseClass realBaseClass = new BaseClass();
+
+        return subClassClass.getMessage("a") + " - " +
+                subClassClassAsBaseClass.getMessage() + " - " +
+                baseClass.getMessage() + " - " +
+                realBaseClass.getMessage() + " - " +
+                subClassAsInterface.getMessage();
+    }
+
+    public static class BaseClass {
+        public String getMessage() {
+            return "Hello world!";
+        }
+    }
+
+    public interface Interface1 {
+        String getMessage();
+        String getMessage(String userName);
+    }
+
+    public static class SubClassClass extends BaseClass implements Interface1 {
+        public String getMessage() {
+            return "Hello world from Mars!";
+        }
+
+        public String getMessage(String userName) {
+            return "Hello " + userName + "!";
+        }
+    }
+
+}

--- a/generator/src/test/java/org/stjs/generator/writer/methods/MethodsGeneratorTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/methods/MethodsGeneratorTest.java
@@ -219,6 +219,29 @@ public class MethodsGeneratorTest extends AbstractStjsTest {
 				"    };");
 	}
 
+	@Test
+	public void testOverrideAndOverloadInSubClass_execute() throws Exception {
+		String result = (String) execute(Methods27_overrride_and_overload_in_subclass_no_conflict.class);
+		Assert.assertEquals("Hello a! - Hello world from Mars! - Hello world from Mars! - Hello world! - Hello world from Mars!", result);
+	}
+
+	@Test
+	public void testOverrideAndOverloadInSubClass_generation() throws Exception {
+		assertCodeContains(Methods27_overrride_and_overload_in_subclass_no_conflict.class, "" +
+				"    constructor.SubClassClass = function(outerClass$0) {\n" +
+				"        this._outerClass$0 = outerClass$0;\n" +
+				"        Methods27_overrride_and_overload_in_subclass_no_conflict.BaseClass.call(this);\n" +
+				"    };\n" +
+				"    constructor.SubClassClass = stjs.extend(constructor.SubClassClass, Methods27_overrride_and_overload_in_subclass_no_conflict.BaseClass, [Methods27_overrride_and_overload_in_subclass_no_conflict.Interface1], function(constructor, prototype) {\n" +
+				"        prototype.getMessage = function() {\n" +
+				"            return \"Hello world from Mars!\";\n" +
+				"        };\n" +
+				"        prototype.getMessage$String = function(userName) {\n" +
+				"            return \"Hello \" + userName + \"!\";\n" +
+				"        };\n" +
+				"    }, {}, {});\n");
+	}
+
 	private void testForbiddenConfiguration(String expectedForbiddenMethod, Class<?> clazz) {
 		Set<String> forbiddenMethodInvocations = new HashSet<>();
 		forbiddenMethodInvocations.add(expectedForbiddenMethod);

--- a/generator/src/test/java/org/stjs/generator/writer/overload/Overload9_no_overload_base_class.java
+++ b/generator/src/test/java/org/stjs/generator/writer/overload/Overload9_no_overload_base_class.java
@@ -3,16 +3,16 @@ package org.stjs.generator.writer.overload;
 public class Overload9_no_overload_base_class {
     public Overload9_no_overload_base_class() {
         BaseClass baseClass = new ExtendedClass();
-        baseClass.overloadMethod(2);
+        baseClass.overloadMethod();
     }
 
     public class BaseClass {
-        public void overloadMethod(int param) {
+        public void overloadMethod() {
         }
     }
 
     public class ExtendedClass extends BaseClass {
-        public void overloadMethod(int param) {
+        public void overloadMethod() {
         }
 
         public void overloadMethod(String param) {

--- a/generator/src/test/java/org/stjs/generator/writer/overload/OverloadTest.java
+++ b/generator/src/test/java/org/stjs/generator/writer/overload/OverloadTest.java
@@ -22,8 +22,13 @@ public class OverloadTest extends AbstractStjsTest {
 		assertCodeContains(Overload6.class, "{prototype.method=function(_arguments){};}");
 	}
 
-	@Test(expected = JavascriptFileGenerationException.class)
-	public void testOverloadNoOverloadInBaseClass() {
-		generate(Overload9_no_overload_base_class.class);
+	@Test
+	public void testOverloadNoOverloadInBaseClass_generation() {
+		assertCodeContains(Overload9_no_overload_base_class.class, "" +
+				"    constructor.ExtendedClass = stjs.extend(constructor.ExtendedClass, Overload9_no_overload_base_class.BaseClass, [], function(constructor, prototype) {\n" +
+				"        prototype.overloadMethod = function() {};\n" +
+				"        prototype.overloadMethod$String = function(param) {};\n" +
+				"    }");
 	}
+
 }


### PR DESCRIPTION
Il reste à fixer le "MethodOverloadManyToSingleCheck". Mais j'ai refactoré et nous ne décorons plus la méthode si la classe de base ne l'avait pas décoré avec les paramètres. Exemple:

``` java
    public class BaseClass {
        public void overloadMethod(int param) {
        }
    }

    public class ExtendedClass extends BaseClass {
        public void overloadMethod(int param) {
        }

        public void overloadMethod(String param) {
        }
    }
```

Une fois généré -->

``` js
    constructor.BaseClass = function(outerClass$0) {
        this._outerClass$0 = outerClass$0;
    };
    constructor.BaseClass = stjs.extend(constructor.BaseClass, null, [], function(constructor, prototype) {
        prototype.overloadMethod = function(param) {};
    }, {}, {});
    constructor.ExtendedClass = function(outerClass$0) {
        this._outerClass$0 = outerClass$0;
        Overload9_no_overload_base_class.BaseClass.call(this);
    };
    constructor.ExtendedClass = stjs.extend(constructor.ExtendedClass, Overload9_no_overload_base_class.BaseClass, [], function(constructor, prototype) {
        prototype.overloadMethod = function(param) {};      // <-- woot! pas décoré!!!
        prototype.overloadMethod$String = function(param) {};
    }, {}, {});

```

Il reste le bug suivant:
`testOverloadNoOverloadInBaseClass_generation``

Si tu regardes ce que ça génère, ça utilise 2 fois la même méthode. Il faut juste corriger ça.
