### PR TITLE
Propose a `javaStringLength` counter part for the java String.length()

### DIFF
--- a/generator/src/main/java/org/stjs/generator/check/declaration/MethodWrongNameCheck.java
+++ b/generator/src/main/java/org/stjs/generator/check/declaration/MethodWrongNameCheck.java
@@ -11,7 +11,7 @@ public class MethodWrongNameCheck implements CheckContributor<MethodTree> {
 
 	@Override
 	public Void visit(CheckVisitor visitor, MethodTree tree, GenerationContext<Void> context) {
-		JavascriptKeywords.checkIdentifier(tree, tree.getName().toString(), context);
+		JavascriptKeywords.checkIdentifier(tree, context.getNames().getMethodName(context, tree), context);
 		return null;
 	}
 


### PR DESCRIPTION
Also make sure to use the converted method name when checking for wrong method name.
